### PR TITLE
[DEVX-1631] Set videoTimestamp prop if applicable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@saucelabs/sauce-json-reporter": "^1.0.0",
+        "@saucelabs/sauce-json-reporter": "1.1.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.0",
         "saucelabs": "^7.0.4"
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/@saucelabs/sauce-json-reporter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.0.0.tgz",
-      "integrity": "sha512-oZAgXeyKv8F6TWXyzg+/MUwo9mL6iTahTvrVYkl6OB2AVAo7pdgNjeJYEcwLes0uhJSXDE7b+iaxER+7SjGufQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.1.0.tgz",
+      "integrity": "sha512-AZcdE6bs6ENEcczUwqAZQ1/5XUKY7XdvCOYNw0bh9Py82c4z3BZv3gorejZRxdsgboFhNvmt3P8M3WpKa6ZIrA=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.7.0",
@@ -8791,9 +8791,9 @@
       }
     },
     "@saucelabs/sauce-json-reporter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.0.0.tgz",
-      "integrity": "sha512-oZAgXeyKv8F6TWXyzg+/MUwo9mL6iTahTvrVYkl6OB2AVAo7pdgNjeJYEcwLes0uhJSXDE7b+iaxER+7SjGufQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.1.0.tgz",
+      "integrity": "sha512-AZcdE6bs6ENEcczUwqAZQ1/5XUKY7XdvCOYNw0bh9Py82c4z3BZv3gorejZRxdsgboFhNvmt3P8M3WpKa6ZIrA=="
     },
     "@sindresorhus/is": {
       "version": "0.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@saucelabs/cypress-plugin",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@saucelabs/sauce-json-reporter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@saucelabs/sauce-json-reporter": "^1.0.0",
+    "@saucelabs/sauce-json-reporter": "1.1.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.0",
     "saucelabs": "^7.0.4"

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -287,9 +287,11 @@ class Reporter {
 
         const tt = suite.withTest(name,{
           status: stateToStatus(t.state),
-          duration: attempt.wallClockDuration,
+          // wallClockDuration is the prop name when handling after:spec, but
+          // its just duration/startedAt when handling after:run
+          duration: attempt.wallClockDuration || attempt.duration,
+          startTime: attempt.wallClockStartedAt || attempt.startedAt,
           output: errorToString(attempt.error),
-          startTime: attempt.wallClockStartedAt,
           code: new TestCode(code),
         });
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -32,7 +32,7 @@ class Reporter {
     this.cypressDetails = cypressDetails;
 
     if (process.env.SAUCE_VIDEO_START_TIME) {
-      this.videoStartTime = Date.parse(process.env.SAUCE_VIDEO_START_TIME);
+      this.videoStartTime = new Date(process.env.SAUCE_VIDEO_START_TIME).getTime();
     }
   }
 
@@ -293,7 +293,7 @@ class Reporter {
         const duration = attempt.wallClockDuration || attempt.duration;
         let videoTimestamp;
         if (this.videoStartTime) {
-          videoTimestamp = (Date.parse(startTime) - this.videoStartTime) / 1000;
+          videoTimestamp = (new Date(startTime).getTime() - this.videoStartTime) / 1000;
         }
 
         const tt = suite.withTest(name, {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -288,7 +288,7 @@ class Reporter {
         const suite = inferSuite(t.title);
         const attempt = t.attempts[t.attempts.length - 1];
         const code = t.body.split("\n");
-        // If results are from 'after:spec', duration and startedAt properties are called wallClockStartedAt and wallClockDuration
+        // If results are from 'after:run', 'wallClockDuration' and 'wallClockStartedAt' properties are called 'duration' and 'startedAt'
         const startTime = attempt.wallClockStartedAt || attempt.startedAt;
         const duration = attempt.wallClockDuration || attempt.duration;
         let videoTimestamp;


### PR DESCRIPTION
* If `SAUCE_VIDEO_START_TIME` is defined as an environment variable, set the `videoTimestamp` property for each test added to the sauce report. Expect the value to be a date in a format parseable by `Date.parse` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse)
* `after:spec` and `after:run` use different property names for duration and startTime, make sure we read the correct times