### PR TITLE
Dedicated Configuration Object for Reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ npm install @saucelabs/cypress-plugin
 
 ### Sauce Labs credentials
 
-`SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables needs to be set to
-allow the plugin to report your results to Sauce Labs.
-Your Sauce Labs Username and Access Key are available from your
+`SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables need to be set for the plugin to report your results to
+Sauce Labs. Your Sauce Labs Username and Access Key are available from your
 [dashboard](https://app.saucelabs.com/user-settings).
 
 ### Plugin setup for Cypress 10+

--- a/README.md
+++ b/README.md
@@ -18,42 +18,76 @@ npm install @saucelabs/cypress-plugin
 
 ## Configuration
 
-### Sauce Labs credentials
+### Sauce Labs Credentials
 
 `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables need to be set for the plugin to report your results to
 Sauce Labs. Your Sauce Labs Username and Access Key are available from your
 [dashboard](https://app.saucelabs.com/user-settings).
 
-### Plugin setup for Cypress 10+
+### Plugin Setup (Cypress 10 and above)
 
 `sauce-cypress-plugin` is configurable through your cypress config file, e.g. `cypress.config.{js,ts}`.
 
 Example `cypress.config.js`:
-```
-const { defineConfig } = require('cypress')
+```javascript
+const {defineConfig} = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      require('@saucelabs/cypress-plugin').default(on, config)
+      require('@saucelabs/cypress-plugin').default(on, config,
+        {
+          region: 'us-west-1',
+          build: 'myBuild',
+          tags: ['example1']
+        }
+      )
       return config
     }
   },
 })
 ```
 
-### Plugin setup before Cypress 10
+Example `cypress.config.ts`:
+```typescript
+import {defineConfig} from 'cypress'
+import Reporter, {Region} from '@saucelabs/cypress-plugin'
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      Reporter(on, config,
+        {
+          region: Region.USWest1, // us-west-1 is the default
+          build: 'myBuild',
+          tags: ['example1']
+        }
+      )
+      return config
+    }
+  },
+})
+```
+
+### Plugin Setup (Cypress 9 and below)
 
 Register the plugin in your project's `cypress/plugins/index.js`:
-```
+```javascript
 module.exports = (on, config) => {
   // Other plugins you may already have.
-  require('@saucelabs/cypress-plugin').default(on, config);
+  // ...
+  require('@saucelabs/cypress-plugin').default(on, config,
+    {
+      region: 'us-west-1',
+      build: 'myBuild',
+      tags: ['example1']
+    }
+  )
   return config
 }
 ```
 
-## Run a test 🚀
+## Run a Test 🚀
 Trigger cypress to run a test
 ```
 cypress run
@@ -69,65 +103,6 @@ Jobs reported to Sauce Labs:
   │  cypress/e2e/1-getting-started/todo.cy.js    https://app.saucelabs.com/tests/b30ffb871827408c81e454103b946c99  │
   └────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
-
-## Configuration
-
-### Configuration for Cypress 10+
-Plugin can be configured in cypress config file, e.g. `cypress.config.{js, ts}`
-
-Example:
-```
-const { defineConfig } = require('cypress')
-
-module.exports = defineConfig({
-  e2e: {
-    setupNodeEvents(on, config) {
-      config['sauce'] = {
-        build: "Cypress Kitchensink Example",
-        tags: [
-          "plugin",
-          "kitchensink",
-          "cypress"
-        ],
-        region: "us-west-1",
-      };
-      require('@saucelabs/cypress-plugin').default(on, config)
-
-      return config
-    }
-  },
-})
-```
-
-| Name | Description | Kind |
-| --- | --- | --- | 
-| build | Sets a build ID | String |
-| tags | Sets tags | Array of String |
-| region | Sets the region (Default: `us-west-1`) | String |
-
-### Configuration before Cypress 10
-`sauce-cypress-plugin` is configurable through your `cypress.json` file.
-
-Example:
-```
-{
-  "sauce": {
-    "build": "Cypress Kitchensink Example",
-    "tags": [
-      "plugin",
-      "kitchensink",
-      "cypress"
-    ],
-    "region": "us-west-1",
-  }
-}
-```
-
-| Name | Description | Kind |
-| --- | --- | --- | 
-| build | Sets a build ID | String |
-| tags | Sets tags | Array of String |
-| region | Sets the region (Default: `us-west-1`) | String |
 
 ## Real-life example
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import BeforeRunDetails = Cypress.BeforeRunDetails;
 import PluginConfigOptions = Cypress.PluginConfigOptions;
 import PluginEvents = Cypress.PluginEvents;
+import Spec = Cypress.Spec;
 
 let reporterInstance: Reporter;
 const reportedSpecs: { name: any; jobURL: string; }[] = [];
@@ -19,7 +20,7 @@ const onBeforeRun = function (details: BeforeRunDetails) {
   reporterInstance = new Reporter(details);
 };
 
-const onAfterSpec = async function (spec: any, results: any) {
+const onAfterSpec = async function (spec: Spec, results: CypressCommandLine.RunResult) {
   if (!accountIsSet()) {
     return;
   }
@@ -72,11 +73,11 @@ const onAfterRun = function () {
  * @param results cypress run results, either from `after:run` or `cypress.run()`
  * @returns {TestRun}
  */
-function afterRunTestReport(results: any) {
+function afterRunTestReport(results: CypressCommandLine.CypressRunResult) {
   const rep = new Reporter(undefined);
 
   const testResults: any[] = [];
-  results.runs?.forEach((run: any) => {
+  results.runs?.forEach(run => {
     testResults.push({spec: run.spec, tests: run.tests, video: run.video});
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,20 @@ import PluginConfigOptions = Cypress.PluginConfigOptions;
 import PluginEvents = Cypress.PluginEvents;
 import Spec = Cypress.Spec;
 
+// Configuration options for the Reporter.
+export interface Options {
+  region: Region
+  build?: string
+  tags?: string[]
+}
+
+// Region is the Sauce Labs cluster region.
+export enum Region {
+  USWest1 = 'us-west-1',
+  EUCentral1 = 'eu-central-1',
+  Staging = 'staging'
+}
+
 let reporterInstance: Reporter;
 const reportedSpecs: { name: any; jobURL: string; }[] = [];
 
@@ -17,7 +31,7 @@ const onBeforeRun = function (details: BeforeRunDetails) {
   if (!accountIsSet()) {
     return;
   }
-  reporterInstance = new Reporter(details);
+  reporterInstance.cypressDetails = details;
 };
 
 const onAfterSpec = async function (spec: Spec, results: CypressCommandLine.RunResult) {
@@ -73,7 +87,7 @@ const onAfterRun = function () {
  * @param results cypress run results, either from `after:run` or `cypress.run()`
  * @returns {TestRun}
  */
-function afterRunTestReport(results: CypressCommandLine.CypressRunResult) {
+export function afterRunTestReport(results: CypressCommandLine.CypressRunResult) {
   const rep = new Reporter(undefined);
 
   const testResults: any[] = [];
@@ -84,9 +98,9 @@ function afterRunTestReport(results: CypressCommandLine.CypressRunResult) {
   return rep.createSauceTestReport(testResults);
 }
 
-module.exports = {afterRunTestReport}
+export default function (on: PluginEvents, config: PluginConfigOptions, opts?: Options) {
+  reporterInstance = new Reporter(undefined, opts);
 
-module.exports.default = function (on: PluginEvents, config: PluginConfigOptions) {
   on('before:run', onBeforeRun);
   on('after:run', onAfterRun);
   on('after:spec', onAfterSpec);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import Spec = Cypress.Spec;
 
 // Configuration options for the Reporter.
 export interface Options {
-  region: Region
+  region?: Region
   build?: string
   tags?: string[]
 }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -31,6 +31,9 @@ export default class Reporter {
     } catch (e) {
     }
 
+    if (!opts.region) {
+      opts.region = Region.USWest1
+    }
     this.opts = opts;
 
     this.api = new SauceLabs({
@@ -261,7 +264,7 @@ export default class Reporter {
     m.set('eu-central-1', 'app.eu-central-1.saucelabs.com')
     m.set('staging', 'app.staging.saucelabs.net')
 
-    return `https://${m.get(this.opts.region)}/tests/${sessionId}`;
+    return `https://${m.get(this.opts.region || Region.USWest1)}/tests/${sessionId}`;
   }
 
   getOsName(osName: string | undefined) {

--- a/tests/integration/cypress.config.js
+++ b/tests/integration/cypress.config.js
@@ -1,9 +1,9 @@
-const { defineConfig } = require('cypress')
+const {defineConfig} = require('cypress')
 
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      config.sauce = {
+      require('../../src/index').default(on, config, {
         build: "Cypress Kitchensink Example",
         tags: [
           "plugin",
@@ -11,8 +11,7 @@ module.exports = defineConfig({
           "cypress"
         ],
         region: "us-west-1",
-      };
-      require('../../src/index').default(on, config)
+      })
 
       return config
     }


### PR DESCRIPTION
Don't hijack cypress' configuration object for our own reporter. Instead, use a dedicated one.