### PR TITLE
Remove Sauce Labs Client Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@saucelabs/sauce-json-reporter": "1.1.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.0",
-        "cypress": "^10.1.0",
         "saucelabs": "^7.0.4"
       },
       "devDependencies": {
@@ -25,6 +24,9 @@
         "jest": "^27.2.4",
         "release-it": "^14.11.6",
         "typescript": "^4.8.3"
+      },
+      "peerDependencies": {
+        "cypress": ">=8"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@saucelabs/sauce-json-reporter": "1.1.0",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.0",
-        "saucelabs": "^7.0.4"
+        "form-data": "^4.0.0"
       },
       "devDependencies": {
         "@tsconfig/node14": "^1.0.3",
@@ -1173,13 +1173,6 @@
       "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.1.0.tgz",
       "integrity": "sha512-AZcdE6bs6ENEcczUwqAZQ1/5XUKY7XdvCOYNw0bh9Py82c4z3BZv3gorejZRxdsgboFhNvmt3P8M3WpKa6ZIrA=="
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "dev": true,
@@ -1198,6 +1191,7 @@
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -1259,6 +1253,7 @@
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -1277,6 +1272,7 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1308,6 +1304,7 @@
     },
     "node_modules/@types/keyv": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1315,6 +1312,7 @@
     },
     "node_modules/@types/node": {
       "version": "16.9.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {
@@ -1329,6 +1327,7 @@
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1896,6 +1895,7 @@
     },
     "node_modules/arch": {
       "version": "2.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1911,23 +1911,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/archive-type": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/archive-type/node_modules/file-type": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -2117,6 +2100,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2146,103 +2130,6 @@
       "version": "2.2.2",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/bin-check": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^0.7.0",
-        "executable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/bin-version": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^1.0.0",
-        "find-versions": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-version-check": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "bin-version": "^3.0.0",
-        "semver": "^5.6.0",
-        "semver-truncate": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-version/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/bin-version/node_modules/execa": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-version/node_modules/get-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bin-wrapper": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "bin-check": "^4.1.0",
-        "bin-version-check": "^4.0.0",
-        "download": "^7.1.0",
-        "import-lazy": "^3.1.0",
-        "os-filter-obj": "^2.0.0",
-        "pify": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/bl": {
-      "version": "1.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
     },
     "node_modules/blob-util": {
       "version": "2.0.2",
@@ -2334,6 +2221,7 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2354,28 +2242,13 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2384,29 +2257,10 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cachedir": {
@@ -2438,14 +2292,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/camelcase": {
       "version": "6.2.0",
       "dev": true,
@@ -2466,33 +2312,11 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/capital-case": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
-    },
-    "node_modules/caw": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "get-proxy": "^2.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "tunnel-agent": "^0.6.0",
-        "url-to-options": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2506,24 +2330,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/change-case": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/char-regex": {
@@ -2654,6 +2460,7 @@
     },
     "node_modules/cliui": {
       "version": "7.0.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2671,6 +2478,7 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -2720,10 +2528,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT"
-    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -2737,14 +2541,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/config-chain": {
-      "version": "1.1.13",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -2784,29 +2580,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/constant-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "node_modules/content-disposition": {
-      "version": "0.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-disposition/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "dev": true,
@@ -2818,10 +2591,6 @@
     "node_modules/convert-source-map/node_modules/safe-buffer": {
       "version": "5.1.2",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -2837,15 +2606,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
       }
     },
     "node_modules/crypto-random-string": {
@@ -3225,140 +2985,21 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tar/node_modules/file-type": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-tarbz2/node_modules/file-type": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-targz/node_modules/file-type": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-unzip": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/file-type": {
-      "version": "3.9.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/get-stream": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress-unzip/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decompress/node_modules/pify": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -3397,6 +3038,7 @@
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3483,14 +3125,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "dev": true,
@@ -3502,62 +3136,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/download": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "archive-type": "^4.0.0",
-        "caw": "^2.0.1",
-        "content-disposition": "^0.5.2",
-        "decompress": "^4.2.0",
-        "ext-name": "^5.0.0",
-        "file-type": "^8.1.0",
-        "filenamify": "^2.0.0",
-        "get-stream": "^3.0.0",
-        "got": "^8.3.1",
-        "make-dir": "^1.2.0",
-        "p-event": "^2.1.0",
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/download/node_modules/got": {
-      "version": "8.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/download/node_modules/pify": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/duplexer3": {
       "version": "0.1.4",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ecc-jsbn": {
@@ -3592,6 +3173,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3618,6 +3200,7 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3633,6 +3216,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -3999,24 +3583,9 @@
       "integrity": "sha512-OHqo4wbHX5VbvlbB6o6eDwhYmiTjrpWACjF8Pmof/GTD6rdBNdZFNck3xlhqOiQFGCOoq3uzHvA0cQpFHIGVAQ==",
       "dev": true
     },
-    "node_modules/execa": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/executable": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.2.0"
@@ -4027,6 +3596,7 @@
     },
     "node_modules/executable/node_modules/pify": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4064,27 +3634,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ext-list": {
-      "version": "2.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.28.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ext-name": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/extend": {
@@ -4199,6 +3748,7 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -4227,32 +3777,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/filename-reserved-regex": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/filenamify": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fill-range": {
@@ -4284,16 +3808,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/find-versions": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "semver-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/flat": {
@@ -4362,18 +3876,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/from2": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -4435,6 +3937,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4459,23 +3962,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proxy": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "npm-conf": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/getos": {
@@ -4608,6 +4094,7 @@
     },
     "node_modules/got": {
       "version": "11.8.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -4631,6 +4118,7 @@
     },
     "node_modules/got/node_modules/@sindresorhus/is": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4641,6 +4129,7 @@
     },
     "node_modules/got/node_modules/cacheable-request": {
       "version": "7.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -4657,6 +4146,7 @@
     },
     "node_modules/got/node_modules/decompress-response": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -4670,6 +4160,7 @@
     },
     "node_modules/got/node_modules/get-stream": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -4683,14 +4174,17 @@
     },
     "node_modules/got/node_modules/http-cache-semantics": {
       "version": "4.1.0",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/got/node_modules/json-buffer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/got/node_modules/keyv": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -4698,6 +4192,7 @@
     },
     "node_modules/got/node_modules/lowercase-keys": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4705,6 +4200,7 @@
     },
     "node_modules/got/node_modules/mimic-response": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4715,6 +4211,7 @@
     },
     "node_modules/got/node_modules/normalize-url": {
       "version": "6.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4725,6 +4222,7 @@
     },
     "node_modules/got/node_modules/p-cancelable": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4732,6 +4230,7 @@
     },
     "node_modules/got/node_modules/responselike": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -4739,6 +4238,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has": {
@@ -4759,13 +4259,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbol-support-x": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.0.2",
       "dev": true,
@@ -4777,38 +4270,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-to-string-tag-x": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbol-support-x": "^1.4.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/has-yarn": {
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/header-case": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -4826,10 +4293,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "3.8.1",
-      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -4860,6 +4323,7 @@
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -4902,6 +4366,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4971,13 +4436,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/import-lazy": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/import-local": {
       "version": "3.0.3",
       "dev": true,
@@ -5021,10 +4479,12 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/inquirer": {
@@ -5057,17 +4517,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/into-stream": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-arrayish": {
@@ -5169,10 +4618,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-natural-number": {
-      "version": "4.0.1",
-      "license": "MIT"
-    },
     "node_modules/is-npm": {
       "version": "5.0.0",
       "dev": true,
@@ -5200,26 +4645,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -5235,26 +4666,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-ssh": {
       "version": "1.3.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocols": "^1.1.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-typedarray": {
@@ -5289,12 +4706,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isstream": {
@@ -5391,17 +4805,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/isurl": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/jest": {
@@ -6411,6 +5814,7 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -6492,6 +5896,7 @@
     },
     "node_modules/keyv": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.0"
@@ -6661,26 +6066,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "4.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
       }
     },
     "node_modules/macos-release": {
@@ -6692,23 +6083,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/make-dir/node_modules/pify": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/makeerror": {
@@ -6771,14 +6145,11 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -6831,18 +6202,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -6889,67 +6248,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/normalize-url/node_modules/sort-keys": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-conf": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-conf/node_modules/pify": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.11.0",
@@ -6961,6 +6263,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7056,16 +6359,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/os-filter-obj": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "arch": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/os-name": {
       "version": "4.0.1",
       "dev": true,
@@ -7094,37 +6387,6 @@
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
       "dev": true
-    },
-    "node_modules/p-cancelable": {
-      "version": "0.4.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-event": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "p-timeout": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-is-promise": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -7164,16 +6426,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-try": {
@@ -7322,14 +6574,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -7421,22 +6665,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -7451,13 +6679,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-parse": {
@@ -7475,6 +6696,7 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/performance-now": {
@@ -7497,30 +6719,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pirates": {
@@ -7555,6 +6753,7 @@
     },
     "node_modules/prepend-http": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7597,10 +6796,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "dev": true,
@@ -7621,10 +6816,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/proto-list": {
-      "version": "1.2.4",
-      "license": "ISC"
-    },
     "node_modules/protocols": {
       "version": "1.4.8",
       "dev": true,
@@ -7636,10 +6827,6 @@
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "dev": true
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "license": "ISC"
-    },
     "node_modules/psl": {
       "version": "1.8.0",
       "dev": true,
@@ -7647,6 +6834,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7686,18 +6874,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/query-string": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "dev": true,
@@ -7719,6 +6895,7 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7752,23 +6929,6 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
       "license": "MIT"
     },
     "node_modules/rechoir": {
@@ -8025,6 +7185,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8052,6 +7213,7 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-cwd": {
@@ -8083,6 +7245,7 @@
     },
     "node_modules/responselike": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^1.0.0"
@@ -8178,6 +7341,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8199,22 +7363,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/saucelabs": {
-      "version": "7.0.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bin-wrapper": "^4.1.0",
-        "change-case": "^4.1.2",
-        "form-data": "^4.0.0",
-        "got": "^11.8.2",
-        "hash.js": "^1.1.7",
-        "tunnel": "^0.0.6",
-        "yargs": "^17.2.1"
-      },
-      "bin": {
-        "sl": "bin/sl"
-      }
-    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "dev": true,
@@ -8224,24 +7372,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/seek-bzip": {
-      "version": "1.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.8.1"
-      },
-      "bin": {
-        "seek-bunzip": "bin/seek-bunzip",
-        "seek-table": "bin/seek-bzip-table"
-      }
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/semver-diff": {
@@ -8261,49 +7391,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver-regex": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semver-truncate": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sentence-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/shelljs": {
@@ -8337,6 +7424,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -8366,34 +7454,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/sort-keys": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-keys-length": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "sort-keys": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map": {
@@ -8470,15 +7530,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/strict-uri-encode": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -8486,6 +7540,7 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-length": {
@@ -8530,20 +7585,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-dirs": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-natural-number": "^4.0.1"
-      }
-    },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "dev": true,
@@ -8561,16 +7602,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-outer": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/supports-color": {
@@ -8636,22 +7667,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tar-stream": {
-      "version": "1.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "dev": true,
@@ -8698,14 +7713,8 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/timed-out": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -8722,10 +7731,6 @@
       "version": "1.0.5",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-buffer": {
-      "version": "1.1.1",
-      "license": "MIT"
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -8772,18 +7777,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/trim-repeated": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.3.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -8807,15 +7803,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/tunnel": {
-      "version": "0.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -8879,14 +7869,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
       }
     },
     "node_modules/unique-string": {
@@ -9003,20 +7985,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/upper-case": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "dev": true,
@@ -9032,6 +8000,7 @@
     },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prepend-http": "^2.0.0"
@@ -9040,15 +8009,9 @@
         "node": ">=4"
       }
     },
-    "node_modules/url-to-options": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -9165,16 +8128,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/widest-line": {
@@ -9332,6 +8285,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9347,6 +8301,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -9398,23 +8353,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "2.1.2",
-      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -9424,24 +8369,9 @@
         "node": ">= 6"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -9449,6 +8379,7 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -10274,9 +9205,6 @@
       "resolved": "https://registry.npmjs.org/@saucelabs/sauce-json-reporter/-/sauce-json-reporter-1.1.0.tgz",
       "integrity": "sha512-AZcdE6bs6ENEcczUwqAZQ1/5XUKY7XdvCOYNw0bh9Py82c4z3BZv3gorejZRxdsgboFhNvmt3P8M3WpKa6ZIrA=="
     },
-    "@sindresorhus/is": {
-      "version": "0.7.0"
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "dev": true,
@@ -10293,6 +9221,7 @@
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
+      "dev": true,
       "requires": {
         "defer-to-connect": "^2.0.0"
       }
@@ -10342,6 +9271,7 @@
     },
     "@types/cacheable-request": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "*",
@@ -10357,7 +9287,8 @@
       }
     },
     "@types/http-cache-semantics": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -10385,12 +9316,14 @@
     },
     "@types/keyv": {
       "version": "3.1.3",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "16.9.6"
+      "version": "16.9.6",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -10402,6 +9335,7 @@
     },
     "@types/responselike": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -10759,18 +9693,8 @@
       }
     },
     "arch": {
-      "version": "2.2.0"
-    },
-    "archive-type": {
-      "version": "4.0.0",
-      "requires": {
-        "file-type": "^4.2.0"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "4.4.0"
-        }
-      }
+      "version": "2.2.0",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -10912,7 +9836,8 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -10926,76 +9851,6 @@
     "before-after-hook": {
       "version": "2.2.2",
       "dev": true
-    },
-    "bin-check": {
-      "version": "4.1.0",
-      "requires": {
-        "execa": "^0.7.0",
-        "executable": "^4.1.0"
-      }
-    },
-    "bin-version": {
-      "version": "3.1.0",
-      "requires": {
-        "execa": "^1.0.0",
-        "find-versions": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "1.0.0",
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
-    "bin-version-check": {
-      "version": "4.0.0",
-      "requires": {
-        "bin-version": "^3.0.0",
-        "semver": "^5.6.0",
-        "semver-truncate": "^1.1.2"
-      }
-    },
-    "bin-wrapper": {
-      "version": "4.1.0",
-      "requires": {
-        "bin-check": "^4.1.0",
-        "bin-version-check": "^4.0.0",
-        "download": "^7.1.0",
-        "import-lazy": "^3.1.0",
-        "os-filter-obj": "^2.0.0",
-        "pify": "^4.0.1"
-      }
-    },
-    "bl": {
-      "version": "1.2.3",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
     },
     "blob-util": {
       "version": "2.0.2",
@@ -11062,50 +9917,23 @@
     },
     "buffer": {
       "version": "5.7.1",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0"
-    },
     "buffer-crc32": {
-      "version": "0.2.13"
-    },
-    "buffer-fill": {
-      "version": "1.0.0"
+      "version": "0.2.13",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.2",
       "dev": true
     },
     "cacheable-lookup": {
-      "version": "5.0.4"
-    },
-    "cacheable-request": {
-      "version": "2.1.4",
-      "requires": {
-        "clone-response": "1.0.2",
-        "get-stream": "3.0.0",
-        "http-cache-semantics": "3.8.1",
-        "keyv": "3.0.0",
-        "lowercase-keys": "1.0.0",
-        "normalize-url": "2.0.1",
-        "responselike": "1.0.2"
-      },
-      "dependencies": {
-        "lowercase-keys": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "5.0.4",
+      "dev": true
     },
     "cachedir": {
       "version": "2.3.0",
@@ -11125,13 +9953,6 @@
       "version": "3.1.0",
       "dev": true
     },
-    "camel-case": {
-      "version": "4.1.2",
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "camelcase": {
       "version": "6.2.0",
       "dev": true
@@ -11140,51 +9961,17 @@
       "version": "1.0.30001265",
       "dev": true
     },
-    "capital-case": {
-      "version": "1.0.4",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
-    "caw": {
-      "version": "2.0.1",
-      "requires": {
-        "get-proxy": "^2.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "tunnel-agent": "^0.6.0",
-        "url-to-options": "^1.0.1"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      }
-    },
-    "change-case": {
-      "version": "4.1.2",
-      "requires": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "char-regex": {
@@ -11268,6 +10055,7 @@
     },
     "cliui": {
       "version": "7.0.4",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -11280,6 +10068,7 @@
     },
     "clone-response": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -11313,9 +10102,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.3"
-    },
     "common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -11325,13 +10111,6 @@
     "concat-map": {
       "version": "0.0.1",
       "dev": true
-    },
-    "config-chain": {
-      "version": "1.1.13",
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
     },
     "configstore": {
       "version": "5.0.1",
@@ -11358,25 +10137,6 @@
         }
       }
     },
-    "constant-case": {
-      "version": "3.0.4",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "content-disposition": {
-      "version": "0.5.3",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2"
-        }
-      }
-    },
     "convert-source-map": {
       "version": "1.8.0",
       "dev": true,
@@ -11390,9 +10150,6 @@
         }
       }
     },
-    "core-util-is": {
-      "version": "1.0.3"
-    },
     "cosmiconfig": {
       "version": "7.0.1",
       "dev": true,
@@ -11402,14 +10159,6 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
-      }
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
       }
     },
     "crypto-random-string": {
@@ -11685,95 +10434,14 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0"
-    },
-    "decompress": {
-      "version": "4.2.1",
-      "requires": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0"
-        }
-      }
+      "version": "0.2.0",
+      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "decompress-tar": {
-      "version": "4.1.1",
-      "requires": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "5.2.0"
-        }
-      }
-    },
-    "decompress-tarbz2": {
-      "version": "4.1.1",
-      "requires": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "6.2.0"
-        }
-      }
-    },
-    "decompress-targz": {
-      "version": "4.1.1",
-      "requires": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "5.2.0"
-        }
-      }
-    },
-    "decompress-unzip": {
-      "version": "4.0.1",
-      "requires": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "3.9.0"
-        },
-        "get-stream": {
-          "version": "2.3.1",
-          "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0"
-        }
       }
     },
     "dedent": {
@@ -11800,7 +10468,8 @@
       }
     },
     "defer-to-connect": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0"
@@ -11852,13 +10521,6 @@
         }
       }
     },
-    "dot-case": {
-      "version": "3.0.4",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "dot-prop": {
       "version": "5.3.0",
       "dev": true,
@@ -11866,52 +10528,9 @@
         "is-obj": "^2.0.0"
       }
     },
-    "download": {
-      "version": "7.1.0",
-      "requires": {
-        "archive-type": "^4.0.0",
-        "caw": "^2.0.1",
-        "content-disposition": "^0.5.2",
-        "decompress": "^4.2.0",
-        "ext-name": "^5.0.0",
-        "file-type": "^8.1.0",
-        "filenamify": "^2.0.0",
-        "get-stream": "^3.0.0",
-        "got": "^8.3.1",
-        "make-dir": "^1.2.0",
-        "p-event": "^2.1.0",
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "got": {
-          "version": "8.3.2",
-          "requires": {
-            "@sindresorhus/is": "^0.7.0",
-            "cacheable-request": "^2.1.1",
-            "decompress-response": "^3.3.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "into-stream": "^3.1.0",
-            "is-retry-allowed": "^1.1.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "mimic-response": "^1.0.0",
-            "p-cancelable": "^0.4.0",
-            "p-timeout": "^2.0.1",
-            "pify": "^3.0.0",
-            "safe-buffer": "^5.1.1",
-            "timed-out": "^4.0.1",
-            "url-parse-lax": "^3.0.0",
-            "url-to-options": "^1.0.1"
-          }
-        },
-        "pify": {
-          "version": "3.0.0"
-        }
-      }
-    },
     "duplexer3": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -11936,6 +10555,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -11955,14 +10575,16 @@
       }
     },
     "escalade": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "escape-goat": {
       "version": "2.1.1",
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "dev": true
     },
     "escodegen": {
       "version": "2.0.0",
@@ -12197,26 +10819,16 @@
       "integrity": "sha512-OHqo4wbHX5VbvlbB6o6eDwhYmiTjrpWACjF8Pmof/GTD6rdBNdZFNck3xlhqOiQFGCOoq3uzHvA0cQpFHIGVAQ==",
       "dev": true
     },
-    "execa": {
-      "version": "0.7.0",
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
     "executable": {
       "version": "4.1.1",
+      "dev": true,
       "requires": {
         "pify": "^2.2.0"
       },
       "dependencies": {
         "pify": {
-          "version": "2.3.0"
+          "version": "2.3.0",
+          "dev": true
         }
       }
     },
@@ -12240,19 +10852,6 @@
           "version": "5.2.0",
           "dev": true
         }
-      }
-    },
-    "ext-list": {
-      "version": "2.2.2",
-      "requires": {
-        "mime-db": "^1.28.0"
-      }
-    },
-    "ext-name": {
-      "version": "5.0.0",
-      "requires": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
@@ -12340,6 +10939,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
+      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -12356,20 +10956,6 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
-      }
-    },
-    "file-type": {
-      "version": "8.1.0"
-    },
-    "filename-reserved-regex": {
-      "version": "2.0.0"
-    },
-    "filenamify": {
-      "version": "2.1.0",
-      "requires": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
       }
     },
     "fill-range": {
@@ -12389,12 +10975,6 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
-      }
-    },
-    "find-versions": {
-      "version": "3.2.0",
-      "requires": {
-        "semver-regex": "^2.0.0"
       }
     },
     "flat": {
@@ -12432,16 +11012,6 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
-    },
-    "from2": {
-      "version": "2.3.0",
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
-    "fs-constants": {
-      "version": "1.0.0"
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -12485,7 +11055,8 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -12499,15 +11070,6 @@
     "get-package-type": {
       "version": "0.1.0",
       "dev": true
-    },
-    "get-proxy": {
-      "version": "2.1.0",
-      "requires": {
-        "npm-conf": "^1.1.0"
-      }
-    },
-    "get-stream": {
-      "version": "3.0.0"
     },
     "getos": {
       "version": "3.2.1",
@@ -12601,6 +11163,7 @@
     },
     "got": {
       "version": "11.8.2",
+      "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -12616,10 +11179,12 @@
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "4.2.0"
+          "version": "4.2.0",
+          "dev": true
         },
         "cacheable-request": {
           "version": "7.0.2",
+          "dev": true,
           "requires": {
             "clone-response": "^1.0.2",
             "get-stream": "^5.1.0",
@@ -12632,42 +11197,52 @@
         },
         "decompress-response": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "mimic-response": "^3.1.0"
           }
         },
         "get-stream": {
           "version": "5.2.0",
+          "dev": true,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0"
+          "version": "4.1.0",
+          "dev": true
         },
         "json-buffer": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "keyv": {
           "version": "4.0.3",
+          "dev": true,
           "requires": {
             "json-buffer": "3.0.1"
           }
         },
         "lowercase-keys": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "dev": true
         },
         "mimic-response": {
-          "version": "3.1.0"
+          "version": "3.1.0",
+          "dev": true
         },
         "normalize-url": {
-          "version": "6.1.0"
+          "version": "6.1.0",
+          "dev": true
         },
         "p-cancelable": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "dev": true
         },
         "responselike": {
           "version": "2.0.0",
+          "dev": true,
           "requires": {
             "lowercase-keys": "^2.0.0"
           }
@@ -12675,7 +11250,8 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8"
+      "version": "4.2.8",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -12687,36 +11263,13 @@
     "has-flag": {
       "version": "4.0.0"
     },
-    "has-symbol-support-x": {
-      "version": "1.4.2"
-    },
     "has-symbols": {
       "version": "1.0.2",
       "dev": true
     },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "requires": {
-        "has-symbol-support-x": "^1.4.1"
-      }
-    },
     "has-yarn": {
       "version": "2.1.0",
       "dev": true
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "header-case": {
-      "version": "2.0.4",
-      "requires": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -12728,9 +11281,6 @@
     "html-escaper": {
       "version": "2.0.2",
       "dev": true
-    },
-    "http-cache-semantics": {
-      "version": "3.8.1"
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -12754,6 +11304,7 @@
     },
     "http2-wrapper": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -12779,7 +11330,8 @@
       }
     },
     "ieee754": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",
@@ -12813,9 +11365,6 @@
         }
       }
     },
-    "import-lazy": {
-      "version": "3.1.0"
-    },
     "import-local": {
       "version": "3.0.3",
       "dev": true,
@@ -12843,10 +11392,12 @@
       }
     },
     "inherits": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "dev": true
     },
     "ini": {
-      "version": "1.3.8"
+      "version": "1.3.8",
+      "dev": true
     },
     "inquirer": {
       "version": "8.1.5",
@@ -12871,13 +11422,6 @@
     "interpret": {
       "version": "1.4.0",
       "dev": true
-    },
-    "into-stream": {
-      "version": "3.1.0",
-      "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
-      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -12933,9 +11477,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "is-natural-number": {
-      "version": "4.0.1"
-    },
     "is-npm": {
       "version": "5.0.0",
       "dev": true
@@ -12948,15 +11489,9 @@
       "version": "2.0.0",
       "dev": true
     },
-    "is-object": {
-      "version": "1.0.2"
-    },
     "is-path-inside": {
       "version": "3.0.3",
       "dev": true
-    },
-    "is-plain-obj": {
-      "version": "1.1.0"
     },
     "is-plain-object": {
       "version": "5.0.0",
@@ -12966,18 +11501,12 @@
       "version": "1.0.1",
       "dev": true
     },
-    "is-retry-allowed": {
-      "version": "1.2.0"
-    },
     "is-ssh": {
       "version": "1.3.3",
       "dev": true,
       "requires": {
         "protocols": "^1.1.0"
       }
-    },
-    "is-stream": {
-      "version": "1.1.0"
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -12998,11 +11527,9 @@
       "version": "0.3.0",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0"
-    },
     "isexe": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -13067,13 +11594,6 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
-      }
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
       }
     },
     "jest": {
@@ -13767,7 +12287,8 @@
       "dev": true
     },
     "json-buffer": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -13832,6 +12353,7 @@
     },
     "keyv": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "json-buffer": "3.0.0"
       }
@@ -13947,36 +12469,13 @@
         }
       }
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "lowercase-keys": {
-      "version": "1.0.1"
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
+      "version": "1.0.1",
+      "dev": true
     },
     "macos-release": {
       "version": "2.5.0",
       "dev": true
-    },
-    "make-dir": {
-      "version": "1.3.0",
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0"
-        }
-      }
     },
     "makeerror": {
       "version": "1.0.11",
@@ -14015,10 +12514,8 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.1"
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -14058,16 +12555,6 @@
         }
       }
     },
-    "nice-try": {
-      "version": "1.0.5"
-    },
-    "no-case": {
-      "version": "3.0.4",
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -14093,46 +12580,9 @@
       "version": "3.0.0",
       "dev": true
     },
-    "normalize-url": {
-      "version": "2.0.1",
-      "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "sort-keys": {
-          "version": "2.0.0",
-          "requires": {
-            "is-plain-obj": "^1.0.0"
-          }
-        }
-      }
-    },
-    "npm-conf": {
-      "version": "1.1.3",
-      "requires": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0"
-        }
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
     "nwsapi": {
       "version": "2.2.0",
       "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1"
     },
     "object-inspect": {
       "version": "1.11.0",
@@ -14140,6 +12590,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -14206,12 +12657,6 @@
         }
       }
     },
-    "os-filter-obj": {
-      "version": "2.0.0",
-      "requires": {
-        "arch": "^2.1.0"
-      }
-    },
     "os-name": {
       "version": "4.0.1",
       "dev": true,
@@ -14229,21 +12674,6 @@
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
       "dev": true
-    },
-    "p-cancelable": {
-      "version": "0.4.1"
-    },
-    "p-event": {
-      "version": "2.3.1",
-      "requires": {
-        "p-timeout": "^2.0.1"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0"
-    },
-    "p-is-promise": {
-      "version": "1.1.0"
     },
     "p-limit": {
       "version": "2.3.0",
@@ -14266,12 +12696,6 @@
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
-      }
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "requires": {
-        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -14371,13 +12795,6 @@
         }
       }
     },
-    "param-case": {
-      "version": "3.0.4",
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -14441,20 +12858,6 @@
       "version": "6.0.1",
       "dev": true
     },
-    "pascal-case": {
-      "version": "3.1.2",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "path-case": {
-      "version": "3.0.4",
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -14462,9 +12865,6 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "dev": true
-    },
-    "path-key": {
-      "version": "2.0.1"
     },
     "path-parse": {
       "version": "1.0.7",
@@ -14475,7 +12875,8 @@
       "dev": true
     },
     "pend": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -14490,18 +12891,6 @@
     "picomatch": {
       "version": "2.3.0",
       "dev": true
-    },
-    "pify": {
-      "version": "4.0.1"
-    },
-    "pinkie": {
-      "version": "2.0.4"
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pirates": {
       "version": "4.0.1",
@@ -14522,7 +12911,8 @@
       "dev": true
     },
     "prepend-http": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",
@@ -14546,9 +12936,6 @@
         }
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1"
-    },
     "progress": {
       "version": "2.0.3",
       "dev": true
@@ -14561,9 +12948,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "proto-list": {
-      "version": "1.2.4"
-    },
     "protocols": {
       "version": "1.4.8",
       "dev": true
@@ -14574,15 +12958,13 @@
       "integrity": "sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==",
       "dev": true
     },
-    "pseudomap": {
-      "version": "1.0.2"
-    },
     "psl": {
       "version": "1.8.0",
       "dev": true
     },
     "pump": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -14606,20 +12988,13 @@
         "side-channel": "^1.0.4"
       }
     },
-    "query-string": {
-      "version": "5.1.1",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "dev": true
     },
     "quick-lru": {
-      "version": "5.1.1"
+      "version": "5.1.1",
+      "dev": true
     },
     "rc": {
       "version": "1.2.8",
@@ -14640,23 +13015,6 @@
     "react-is": {
       "version": "17.0.2",
       "dev": true
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2"
-        }
-      }
     },
     "rechoir": {
       "version": "0.6.2",
@@ -14820,7 +13178,8 @@
       }
     },
     "require-directory": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -14835,7 +13194,8 @@
       }
     },
     "resolve-alpn": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "resolve-cwd": {
       "version": "3.0.0",
@@ -14856,6 +13216,7 @@
     },
     "responselike": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -14910,23 +13271,12 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1"
+      "version": "5.2.1",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "dev": true
-    },
-    "saucelabs": {
-      "version": "7.0.4",
-      "requires": {
-        "bin-wrapper": "^4.1.0",
-        "change-case": "^4.1.2",
-        "form-data": "^4.0.0",
-        "got": "^11.8.2",
-        "hash.js": "^1.1.7",
-        "tunnel": "^0.0.6",
-        "yargs": "^17.2.1"
-      }
     },
     "saxes": {
       "version": "5.0.1",
@@ -14934,15 +13284,6 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
-    },
-    "seek-bzip": {
-      "version": "1.0.6",
-      "requires": {
-        "commander": "^2.8.1"
-      }
-    },
-    "semver": {
-      "version": "5.7.1"
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -14956,32 +13297,6 @@
           "dev": true
         }
       }
-    },
-    "semver-regex": {
-      "version": "2.0.0"
-    },
-    "semver-truncate": {
-      "version": "1.1.2",
-      "requires": {
-        "semver": "^5.3.0"
-      }
-    },
-    "sentence-case": {
-      "version": "3.0.4",
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0"
     },
     "shelljs": {
       "version": "0.8.4",
@@ -15002,7 +13317,8 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "dev": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -15019,25 +13335,6 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
-    "snake-case": {
-      "version": "3.0.4",
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "sort-keys": {
-      "version": "1.1.2",
-      "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
-    "sort-keys-length": {
-      "version": "1.0.1",
-      "requires": {
-        "sort-keys": "^1.0.0"
       }
     },
     "source-map": {
@@ -15090,17 +13387,16 @@
         }
       }
     },
-    "strict-uri-encode": {
-      "version": "1.1.0"
-    },
     "string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.1.2"
+          "version": "5.1.2",
+          "dev": true
         }
       }
     },
@@ -15130,15 +13426,6 @@
       "version": "4.0.0",
       "dev": true
     },
-    "strip-dirs": {
-      "version": "2.1.0",
-      "requires": {
-        "is-natural-number": "^4.0.1"
-      }
-    },
-    "strip-eof": {
-      "version": "1.0.0"
-    },
     "strip-final-newline": {
       "version": "2.0.0",
       "dev": true
@@ -15146,12 +13433,6 @@
     "strip-json-comments": {
       "version": "3.1.1",
       "dev": true
-    },
-    "strip-outer": {
-      "version": "1.0.1",
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
-      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -15199,18 +13480,6 @@
         }
       }
     },
-    "tar-stream": {
-      "version": "1.6.2",
-      "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
-      }
-    },
     "terminal-link": {
       "version": "2.1.1",
       "dev": true,
@@ -15243,10 +13512,8 @@
       "dev": true
     },
     "through": {
-      "version": "2.3.8"
-    },
-    "timed-out": {
-      "version": "4.0.1"
+      "version": "2.3.8",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -15258,9 +13525,6 @@
     "tmpl": {
       "version": "1.0.5",
       "dev": true
-    },
-    "to-buffer": {
-      "version": "1.1.1"
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -15290,14 +13554,9 @@
       "version": "0.0.3",
       "dev": true
     },
-    "trim-repeated": {
-      "version": "1.0.0",
-      "requires": {
-        "escape-string-regexp": "^1.0.2"
-      }
-    },
     "tslib": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -15316,11 +13575,9 @@
         }
       }
     },
-    "tunnel": {
-      "version": "0.0.6"
-    },
     "tunnel-agent": {
       "version": "0.6.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -15358,13 +13615,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
-    },
-    "unbzip2-stream": {
-      "version": "1.4.3",
-      "requires": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
     },
     "unique-string": {
       "version": "2.0.0",
@@ -15442,18 +13692,6 @@
         }
       }
     },
-    "upper-case": {
-      "version": "2.0.2",
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "upper-case-first": {
-      "version": "2.0.2",
-      "requires": {
-        "tslib": "^2.0.3"
-      }
-    },
     "uri-js": {
       "version": "4.4.1",
       "dev": true,
@@ -15467,15 +13705,14 @@
     },
     "url-parse-lax": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
       }
     },
-    "url-to-options": {
-      "version": "1.0.1"
-    },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -15570,12 +13807,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "which": {
-      "version": "1.3.1",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
     "widest-line": {
       "version": "3.1.0",
       "dev": true,
@@ -15666,6 +13897,7 @@
     },
     "wrap-ansi": {
       "version": "7.0.0",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -15673,7 +13905,8 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -15702,36 +13935,21 @@
       "version": "2.2.0",
       "dev": true
     },
-    "xtend": {
-      "version": "4.0.2"
-    },
     "y18n": {
-      "version": "5.0.8"
-    },
-    "yallist": {
-      "version": "2.1.2"
+      "version": "5.0.8",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",
       "dev": true
     },
-    "yargs": {
-      "version": "17.2.1",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
     "yargs-parser": {
-      "version": "20.2.9"
+      "version": "20.2.9",
+      "dev": true
     },
     "yauzl": {
       "version": "2.10.0",
+      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "@saucelabs/sauce-json-reporter": "1.1.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.0",
-    "cypress": "^10.1.0",
     "saucelabs": "^7.0.4"
+  },
+  "peerDependencies": {
+    "cypress": ">=8"
   },
   "devDependencies": {
     "@tsconfig/node14": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "build": "tsc",
+    "watch": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
     "release": "tsc && release-it --github.release",
@@ -34,7 +35,7 @@
     "@saucelabs/sauce-json-reporter": "1.1.0",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.0",
-    "saucelabs": "^7.0.4"
+    "form-data": "^4.0.0"
   },
   "peerDependencies": {
     "cypress": ">=8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Reporter from './reporter'
+import Reporter, {RunResult} from './reporter'
 import Table from "cli-table3";
 import chalk from "chalk";
 import BeforeRunDetails = Cypress.BeforeRunDetails;
@@ -35,7 +35,7 @@ const onAfterSpec = async function (spec: Spec, results: CypressCommandLine.RunR
     return;
   }
   try {
-    const {url} = await reporterInstance.reportSpec(results);
+    const {url} = await reporterInstance.reportSpec(results as RunResult);
     reportedSpecs.push({
       name: spec.name,
       jobURL: url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export interface Options {
 }
 
 let reporterInstance: Reporter;
-const reportedSpecs: { name: any; jobURL: string; }[] = [];
+const reportedSpecs: { name: string; jobURL: string; }[] = [];
 
 const accountIsSet = function () {
   return process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY;
@@ -34,19 +34,17 @@ const onAfterSpec = async function (spec: Spec, results: CypressCommandLine.RunR
   if (!accountIsSet()) {
     return;
   }
-  try {
-    const {url} = await reporterInstance.reportSpec(results as RunResult);
-    reportedSpecs.push({
-      name: spec.name,
-      jobURL: url,
-    });
 
-    console.log(`Report created: ${url}`);
-  } catch (e) {
-    if (e instanceof Error) {
-      console.error(`Failed to report ${spec.name} to Sauce Labs:`, e.message);
+  reporterInstance.reportSpec(results as RunResult).then(
+    job => {
+      reportedSpecs.push({
+        name: spec.name,
+        jobURL: job.url,
+      });
+
+      console.log(`Report created: ${job.url}`);
     }
-  }
+  ).catch(e => console.error(`Failed to report ${spec.name} to Sauce Labs:`, e.message))
 }
 
 const onAfterRun = function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,9 @@ const onAfterSpec = async function (spec: Spec, results: CypressCommandLine.RunR
 
     console.log(`Report created: ${url}`);
   } catch (e) {
-    console.error(`Failed to report ${spec.name} to Sauce Labs:`, e);
+    if (e instanceof Error) {
+      console.error(`Failed to report ${spec.name} to Sauce Labs:`, e.message);
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,19 +5,15 @@ import BeforeRunDetails = Cypress.BeforeRunDetails;
 import PluginConfigOptions = Cypress.PluginConfigOptions;
 import PluginEvents = Cypress.PluginEvents;
 import Spec = Cypress.Spec;
+import {Region} from "./region";
+
+export {Region}
 
 // Configuration options for the Reporter.
 export interface Options {
   region?: Region
   build?: string
   tags?: string[]
-}
-
-// Region is the Sauce Labs cluster region.
-export enum Region {
-  USWest1 = 'us-west-1',
-  EUCentral1 = 'eu-central-1',
-  Staging = 'staging'
 }
 
 let reporterInstance: Reporter;

--- a/src/region.ts
+++ b/src/region.ts
@@ -1,0 +1,6 @@
+// Region is the Sauce Labs cluster region.
+export enum Region {
+  USWest1 = 'us-west-1',
+  EUCentral1 = 'eu-central-1',
+  Staging = 'staging'
+}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -132,14 +132,10 @@ export default class Reporter {
     const assets = [];
 
     // Since reporting is made by spec, there is only one video to upload.
-    try {
-      assets.push({
-        data: fs.createReadStream(video),
-        filename: VIDEO_FILENAME,
-      });
-    } catch (e) {
-      console.error(`Failed to load video ${video}:`, e);
-    }
+    assets.push({
+      data: fs.createReadStream(video),
+      filename: VIDEO_FILENAME,
+    });
 
     // Add generated console.log
     const logReadable = new stream.Readable();
@@ -163,14 +159,10 @@ export default class Reporter {
 
     // Add screenshots
     for (const s of screenshots) {
-      try {
-        assets.push({
-          data: fs.createReadStream(s),
-          filename: path.basename(s)
-        });
-      } catch (e) {
-        console.error(`Failed to load screenshot ${s}:`, e)
-      }
+      assets.push({
+        data: fs.createReadStream(s),
+        filename: path.basename(s)
+      });
     }
 
     this.testComposer.uploadAssets(sessionId || '', assets).then(

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -75,13 +75,7 @@ export default class Reporter {
     });
     this.sessionId = job.id;
 
-    const consoleLogContent = this.getConsoleLog({
-      spec: result.spec,
-      stats: result.reporterStats,
-      tests: result.tests,
-      // @ts-ignore
-      screenshots: result.screenshots
-    });
+    const consoleLogContent = this.getConsoleLog(result);
     // @ts-ignore
     const screenshotsPath = result.screenshots.map((s: any) => s.path);
     const report = this.createSauceTestReport([{
@@ -147,27 +141,30 @@ export default class Reporter {
     )
   }
 
-  getConsoleLog(run: any) {
-    let consoleLog = `Running: ${run.spec.name}\n\n`;
+  getConsoleLog(result: CypressCommandLine.RunResult) {
+    let consoleLog = `Running: ${result.spec.name}\n\n`;
 
-    const tree = this.orderContexts(run.tests);
+    const tree = this.orderContexts(result.tests);
     consoleLog = consoleLog.concat(
       this.formatResults(tree)
     );
+
+    // @ts-ignore
+    const numScreenshots = result.screenshots?.length || 0;
 
     consoleLog = consoleLog.concat(`
       
   Results:
 
-    Tests:        ${run.stats.tests || 0}
-    Passing:      ${run.stats.passes || 0}
-    Failing:      ${run.stats.failures || 0}
-    Pending:      ${run.stats.pending || 0}
-    Skipped:      ${run.stats.skipped || 0}
-    Screenshots:  ${run.screenshots?.length || 0}
-    Video:        ${run.video != ''}
-    Duration:     ${Math.floor(run.stats.duration / 1000)} seconds
-    Spec Ran:     ${run.spec.name}
+    Tests:        ${result.stats.tests || 0}
+    Passing:      ${result.stats.passes || 0}
+    Failing:      ${result.stats.failures || 0}
+    Pending:      ${result.stats.pending || 0}
+    Skipped:      ${result.stats.skipped || 0}
+    Screenshots:  ${numScreenshots}
+    Video:        ${result.video != ''}
+    Duration:     ${Math.floor(result.stats.duration / 1000)} seconds
+    Spec Ran:     ${result.spec.name}
 
       `);
     consoleLog = consoleLog.concat(`\n\n`);

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -65,20 +65,19 @@ export default class Reporter {
       suiteName = `${this.opts.build} - ${spec.name}`;
     }
 
-
-    const body = this.createBody({
-      startedAt: start,
-      endedAt: end,
+    await this.createJob({
+      name: suiteName,
+      startTime: start,
+      endTime: end,
+      framework: 'cypress',
+      frameworkVersion: this.cypressDetails?.cypressVersion || '0.0.0',
+      passed: failures === 0,
+      tags: this.opts.tags,
+      build: this.opts.build,
       browserName: this.cypressDetails?.browser?.name,
       browserVersion: this.cypressDetails?.browser?.version,
-      cypressVersion: this.cypressDetails?.cypressVersion,
-      build: this.opts.build,
-      tags: this.opts.tags,
-      success: failures === 0,
-      suiteName,
+      platformName: this.getOsName(this.cypressDetails?.system?.osName),
     });
-
-    await this.createJob(body);
 
     const consoleLogContent = this.getConsoleLog({spec, stats: reporterStats, tests, screenshots});
     const screenshotsPath = screenshots.map((s: any) => s.path);
@@ -95,37 +94,6 @@ export default class Reporter {
     const job = await this.testComposer.createReport(body);
     this.sessionId = job.id;
     return this.sessionId;
-  }
-
-  createBody({
-               suiteName,
-               startedAt,
-               endedAt,
-               cypressVersion,
-               success,
-               tags,
-               build,
-               browserName,
-               browserVersion,
-             }: any) {
-
-    return {
-      name: suiteName,
-      user: process.env.SAUCE_USERNAME,
-      startTime: startedAt,
-      endTime: endedAt,
-      framework: 'cypress',
-      frameworkVersion: cypressVersion,
-      status: 'complete',
-      suite: suiteName,
-      errors: [], // To Add
-      passed: success,
-      tags: tags,
-      build: build,
-      browserName,
-      browserVersion,
-      platformName: this.getOsName(this.cypressDetails?.system?.osName),
-    };
   }
 
   async uploadAssets(sessionId: string | undefined, video: string, consoleLogContent: string, screenshots: string[], testReport: TestRun) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -40,7 +40,6 @@ export default class Reporter {
 
   private opts: Options;
   private readonly videoStartTime: number | undefined;
-  private sessionId = '';
   private testComposer: TestComposer;
 
   constructor(
@@ -95,7 +94,6 @@ export default class Reporter {
       browserVersion: this.cypressDetails?.browser?.version,
       platformName: this.getOsName(this.cypressDetails?.system?.osName)
     });
-    this.sessionId = job.id;
 
     const consoleLogContent = this.getConsoleLog(result);
     const screenshotsPath = result.screenshots.map((s) => s.path);
@@ -105,7 +103,7 @@ export default class Reporter {
       video: result.video,
       screenshots: result.screenshots
     }]);
-    await this.uploadAssets(this.sessionId, result.video, consoleLogContent, screenshotsPath, report);
+    await this.uploadAssets(job.id, result.video, consoleLogContent, screenshotsPath, report);
 
     return job;
   }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,5 +1,4 @@
 import * as Cypress from "cypress";
-import SauceLabs from "saucelabs";
 import path from "path";
 import fs from "fs";
 import {Status, TestCode, TestRun} from "@saucelabs/sauce-json-reporter";

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -155,7 +155,7 @@ export default class Reporter {
           }
         }
       },
-      (e: Error) => console.log('Failed to upload assets:', e.message)
+      (e: Error) => console.error('Failed to upload assets:', e.message)
     )
   }
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -3,7 +3,7 @@ import path from "path";
 import fs from "fs";
 import {Status, TestCode, TestRun} from "@saucelabs/sauce-json-reporter";
 import {Options} from "./index";
-import {CreateReportRequest, TestComposer} from "./testcomposer";
+import {TestComposer} from "./testcomposer";
 import BeforeRunDetails = Cypress.BeforeRunDetails;
 import {Region} from "./region";
 import * as stream from "stream";
@@ -85,10 +85,7 @@ export default class Reporter {
     const report = this.createSauceTestReport([{spec, tests, video, screenshots}]);
     await this.uploadAssets(this.sessionId, video, consoleLogContent, screenshotsPath, report);
 
-    return {
-      sessionId: this.sessionId,
-      url: this.generateJobLink(this.sessionId),
-    };
+    return job;
   }
 
   async uploadAssets(sessionId: string | undefined, video: string, consoleLogContent: string, screenshots: string[], testReport: TestRun) {
@@ -211,15 +208,6 @@ export default class Reporter {
       txt = txt.concat(this.formatResults(node.children[child], level + 1));
     }
     return txt;
-  }
-
-  generateJobLink(sessionId: string) {
-    const m = new Map<string, string>();
-    m.set('us-west-1', 'app.saucelabs.com')
-    m.set('eu-central-1', 'app.eu-central-1.saucelabs.com')
-    m.set('staging', 'app.staging.saucelabs.net')
-
-    return `https://${m.get(this.opts.region || Region.USWest1)}/tests/${sessionId}`;
   }
 
   getOsName(osName: string | undefined) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -108,7 +108,7 @@ export default class Reporter {
     return job;
   }
 
-  async uploadAssets(sessionId: string | undefined, video: string | null, consoleLogContent: string, screenshots: string[], testReport: TestRun) {
+  async uploadAssets(jobId: string | undefined, video: string | null, consoleLogContent: string, screenshots: string[], testReport: TestRun) {
     const assets = [];
 
     // Since reporting is made by spec, there is only one video to upload.
@@ -147,7 +147,7 @@ export default class Reporter {
       });
     }
 
-    this.testComposer.uploadAssets(sessionId || '', assets).then(
+    this.testComposer.uploadAssets(jobId || '', assets).then(
       (resp) => {
         if (resp.errors) {
           for (const err of resp.errors) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -65,7 +65,7 @@ export default class Reporter {
       suiteName = `${this.opts.build} - ${spec.name}`;
     }
 
-    await this.createJob({
+    const job = await this.testComposer.createReport({
       name: suiteName,
       startTime: start,
       endTime: end,
@@ -78,6 +78,7 @@ export default class Reporter {
       browserVersion: this.cypressDetails?.browser?.version,
       platformName: this.getOsName(this.cypressDetails?.system?.osName),
     });
+    this.sessionId = job.id;
 
     const consoleLogContent = this.getConsoleLog({spec, stats: reporterStats, tests, screenshots});
     const screenshotsPath = screenshots.map((s: any) => s.path);
@@ -88,12 +89,6 @@ export default class Reporter {
       sessionId: this.sessionId,
       url: this.generateJobLink(this.sessionId),
     };
-  }
-
-  async createJob(body: CreateReportRequest) {
-    const job = await this.testComposer.createReport(body);
-    this.sessionId = job.id;
-    return this.sessionId;
   }
 
   async uploadAssets(sessionId: string | undefined, video: string, consoleLogContent: string, screenshots: string[], testReport: TestRun) {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -173,7 +173,7 @@ export default class Reporter {
           }
         }
       },
-      (e: Error) => console.log('Failed to upload assets:', e)
+      (e: Error) => console.log('Failed to upload assets:', e.message)
     )
   }
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -8,6 +8,7 @@ import BeforeRunDetails = Cypress.BeforeRunDetails;
 import {Region} from "./region";
 import * as stream from "stream";
 import ScreenshotInformation = CypressCommandLine.ScreenshotInformation;
+import TestResult = CypressCommandLine.TestResult;
 
 // Once the UI is able to dynamically show videos, we can remove this and simply use whatever video name
 // the framework provides.
@@ -187,7 +188,7 @@ export default class Reporter {
     return consoleLog;
   }
 
-  orderContexts(tests: any) {
+  orderContexts(tests: TestResult[]) {
     let arch = {name: '', values: [], children: {}};
 
     for (const test of tests) {
@@ -196,7 +197,7 @@ export default class Reporter {
     return arch;
   }
 
-  placeInContext(arch: any, title: any, test: any) {
+  placeInContext(arch: any, title: string[], test: TestResult) {
     if (title.length === 1) {
       arch.values.push({title: title[0], result: test});
       return arch;

--- a/src/testcomposer.ts
+++ b/src/testcomposer.ts
@@ -26,16 +26,16 @@ export interface Options {
 
 export interface CreateReportRequest {
   name: string
-  browserName: string
-  browserVersion: string
+  browserName?: string
+  browserVersion?: string
   platformName: string
   framework: string
   frameworkVersion: string
   passed: boolean
   startTime: string
   endTime: string
-  build: string
-  tags: string[]
+  build?: string
+  tags?: string[]
 }
 
 interface CreateReportResponse {

--- a/src/testcomposer.ts
+++ b/src/testcomposer.ts
@@ -1,0 +1,89 @@
+import axios, {AxiosRequestConfig} from "axios";
+import {Region} from "./region";
+import FormData from "form-data";
+import * as stream from "stream";
+
+const apiURLMap = new Map<Region, string>([
+    [Region.USWest1, 'https://api.us-west-1.saucelabs.com/v1/testcomposer'],
+    [Region.EUCentral1, 'https://api.eu-central-1.saucelabs.com/v1/testcomposer'],
+    [Region.Staging, 'https://api.staging.saucelabs.net/v1/testcomposer']
+  ]
+);
+
+const appURLMap = new Map<Region, string>([
+    [Region.USWest1, 'https://app.saucelabs.com'],
+    [Region.EUCentral1, 'https://app.eu-central-1.saucelabs.com'],
+    [Region.Staging, 'https://api.staging.saucelabs.net']
+  ]
+);
+
+export interface Options {
+  region: Region
+  username: string
+  accessKey: string
+  headers: Record<string, string | number | boolean>
+}
+
+export interface CreateReportRequest {
+  name: string
+  browserName: string
+  browserVersion: string
+  platformName: string
+  framework: string
+  frameworkVersion: string
+  passed: boolean
+  startTime: string
+  endTime: string
+  build: string
+  tags: string[]
+}
+
+interface CreateReportResponse {
+  ID: string
+}
+
+export interface Asset {
+  filename: string
+  data: stream.Readable
+}
+
+export interface UploadAssetResponse {
+  uploaded: string[]
+  errors: string[]
+}
+
+export class TestComposer {
+  private readonly opts: Options
+  private readonly requestConfig: AxiosRequestConfig
+
+  private readonly url: string
+
+  constructor(opts: Options) {
+    this.opts = opts;
+    this.url = apiURLMap.get(opts.region) || Region.USWest1;
+    this.requestConfig = {auth: {username: this.opts.username, password: this.opts.accessKey}, headers: opts.headers};
+  }
+
+  async createReport(req: CreateReportRequest) {
+    const resp = await axios.post(this.url + '/reports', req, this.requestConfig);
+
+    // TODO error handling (non 201 response codes)
+
+    const id = (resp.data as CreateReportResponse).ID;
+    return {id: id, url: appURLMap.get(this.opts.region) + '/tests/' + id};
+  }
+
+  async uploadAssets(jobId: string, assets: Asset[]) {
+    const form = new FormData();
+    for (const asset of assets) {
+      console.log(`Adding ${asset.filename}`);
+      form.append('file', asset.data, {filename: asset.filename});
+    }
+
+    const resp = await axios.put(this.url + `/jobs/${jobId}/assets`, form, this.requestConfig);
+
+    // TODO error handling (non 200 response codes)
+
+    return resp.data as UploadAssetResponse;
+  }
+}

--- a/src/testcomposer.ts
+++ b/src/testcomposer.ts
@@ -21,7 +21,7 @@ export interface Options {
   region: Region
   username: string
   accessKey: string
-  headers: Record<string, string | number | boolean>
+  headers?: Record<string, string | number | boolean>
 }
 
 export interface CreateReportRequest {

--- a/src/testcomposer.ts
+++ b/src/testcomposer.ts
@@ -76,7 +76,6 @@ export class TestComposer {
   async uploadAssets(jobId: string, assets: Asset[]) {
     const form = new FormData();
     for (const asset of assets) {
-      console.log(`Adding ${asset.filename}`);
       form.append('file', asset.data, {filename: asset.filename});
     }
 

--- a/src/testcomposer.ts
+++ b/src/testcomposer.ts
@@ -67,8 +67,6 @@ export class TestComposer {
   async createReport(req: CreateReportRequest) {
     const resp = await axios.post(this.url + '/reports', req, this.requestConfig);
 
-    // TODO error handling (non 201 response codes)
-
     const id = (resp.data as CreateReportResponse).ID;
     return {id: id, url: appURLMap.get(this.opts.region) + '/tests/' + id};
   }
@@ -80,8 +78,6 @@ export class TestComposer {
     }
 
     const resp = await axios.put(this.url + `/jobs/${jobId}/assets`, form, this.requestConfig);
-
-    // TODO error handling (non 200 response codes)
 
     return resp.data as UploadAssetResponse;
   }


### PR DESCRIPTION
Remove the Sauce Labs client as a dependency, shrinking our dependencies by a significant 30MB (lack of sauce connect).

Improved error handling and type definitions along the way.