### PR TITLE
Fix out of order printing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,16 +35,19 @@ const onAfterSpec = async function (spec: Spec, results: CypressCommandLine.RunR
     return;
   }
 
-  reporterInstance.reportSpec(results as RunResult).then(
-    job => {
-      reportedSpecs.push({
-        name: spec.name,
-        jobURL: job.url,
-      });
+  try {
+    const job = await reporterInstance.reportSpec(results as RunResult)
+    reportedSpecs.push({
+      name: spec.name,
+      jobURL: job.url,
+    });
 
-      console.log(`Report created: ${job.url}`);
+    console.log(`Report created: ${job.url}`);
+  } catch (e) {
+    if (e instanceof Error) {
+      console.error(`Failed to report ${spec.name} to Sauce Labs:`, e.message)
     }
-  ).catch(e => console.error(`Failed to report ${spec.name} to Sauce Labs:`, e.message))
+  }
 }
 
 const onAfterRun = function () {


### PR DESCRIPTION
Chaining the promise with `then`, causes print statements to appear out of order when multiple reporters are used.

For example:
```
  (Video)

  -  Started processing:  Compressing to 32 CRF
Report created: https://app.saucelabs.com/tests/95d9b29035f5458fadd4be67885130ac
  -  Finished processing: /Users/alexplischke/devel/saucectl-cypress-example/v1/cypre    (0 seconds)
                          ss/videos/traversal.cy.js.mp4
```