### PR TITLE
chore: Add stricter type checking

### DIFF
--- a/src/@types/cypress.d.ts
+++ b/src/@types/cypress.d.ts
@@ -1,0 +1,129 @@
+// The official Cypress types are not always accurate, so we need to extend them.
+// See https://github.com/cypress-io/cypress/issues/23805 for more information.
+//
+/// <reference path="../../node_modules/cypress/types/cypress-npm-api.d.ts"/>
+declare namespace cypress {
+  import ms = CypressCommandLine.ms;
+  import dateTimeISO = CypressCommandLine.dateTimeISO;
+  import HookInformation = CypressCommandLine.HookInformation;
+  import pixels = CypressCommandLine.pixels;
+
+  interface CypressRunResult {
+    status: 'finished'
+    startedTestsAt: dateTimeISO
+    endedTestsAt: dateTimeISO
+    totalDuration: ms
+    totalSuites: number
+    totalTests: number
+    totalFailed: number
+    totalPassed: number
+    totalPending: number
+    totalSkipped: number
+    /**
+     * If Cypress test run is being recorded, full url will be provided.
+     * @see https://on.cypress.io/dashboard-introduction
+     */
+    runUrl?: string
+    runs: RunResult[]
+    browserPath: string
+    browserName: string
+    browserVersion: string
+    osName: string
+    osVersion: string
+    cypressVersion: string
+    config: Cypress.ResolvedConfigOptions
+  }
+
+  interface RunResult {
+    screenshots: ScreenshotInformation[]
+
+    stats: {
+      suites: number
+      tests: number
+      passes: number
+      pending: number
+      skipped: number
+      failures: number
+      startedAt?: dateTimeISO
+      endedAt?: dateTimeISO
+      duration?: ms
+      wallClockStartedAt?: dateTimeISO
+      wallClockEndedAt?: dateTimeISO
+      wallClockDuration?: ms
+    }
+
+    /**
+     * Reporter name like "spec"
+     */
+    reporter: string
+    /**
+     * This is controlled by the reporter, and Cypress cannot guarantee
+     * the properties. Usually this object has suites, tests, passes, etc
+     */
+    reporterStats: object
+    hooks: HookInformation[]
+    tests: TestResult[]
+    error: string | null
+    video: string | null
+    /**
+     * information about the spec test file.
+     */
+    spec: {
+      /**
+       * filename like "spec.js"
+       */
+      name: string
+      /**
+       * name relative to the project root, like "cypress/integration/spec.js"
+       */
+      relative: string
+      /**
+       * resolved filename of the spec
+       */
+      absolute: string
+      relativeToCommonRoot: string
+    }
+    shouldUploadVideo: boolean
+    skippedSpec: boolean
+  }
+
+  interface TestResult {
+    testId: string
+    title: string[]
+    state: string
+    body: string
+    displayError: string | null
+    attempts: AttemptResult[]
+  }
+
+  interface TestError {
+    name: string
+    message: string
+    stack: string
+    codeFrame?: { line: number, column: number, frame: string, originalFile?: string };
+  }
+
+  interface AttemptResult {
+    state: string
+    error: TestError | null
+    wallClockStartedAt?: dateTimeISO
+    wallClockDuration?: ms
+    startedAt?: dateTimeISO
+    duration?: ms
+    videoTimestamp: ms
+    screenshots?: ScreenshotInformation[]
+  }
+
+  interface ScreenshotInformation {
+    screenshotId: string
+    name: string
+    testId: string
+    takenAt: dateTimeISO
+    /**
+     * Absolute path to the saved image
+     */
+    path: string
+    height: pixels
+    width: pixels
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Reporter, {RunResult} from './reporter'
+import Reporter from './reporter'
 import Table from "cli-table3";
 import chalk from "chalk";
 import BeforeRunDetails = Cypress.BeforeRunDetails;
@@ -6,6 +6,7 @@ import PluginConfigOptions = Cypress.PluginConfigOptions;
 import PluginEvents = Cypress.PluginEvents;
 import Spec = Cypress.Spec;
 import {Region} from "@saucelabs/testcomposer";
+import RunResult = cypress.RunResult;
 
 export {Region}
 
@@ -92,14 +93,13 @@ const onAfterRun = function () {
  * Converts the results of a cypress run (the result from `after:run` or `cypress.run()`) to a sauce test report.
  *
  * @param results cypress run results, either from `after:run` or `cypress.run()`
- * @returns {TestRun}
  */
-export async function afterRunTestReport(results: CypressCommandLine.CypressRunResult) {
+export async function afterRunTestReport(results: cypress.CypressRunResult) {
   const rep = new Reporter(undefined);
 
-  const testResults: any[] = [];
+  const testResults: RunResult[] = [];
   results.runs?.forEach(run => {
-    testResults.push({spec: run.spec, tests: run.tests, video: run.video});
+    testResults.push(run);
   });
 
   return await rep.createSauceTestReport(testResults);

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -107,14 +107,14 @@ export default class Reporter {
       .filter((test) => test.attempts.length > 0)
       .map((test) => {
         const attempt = test.attempts[test.attempts.length - 1];
-        const startDate = new Date(attempt.wallClockStartedAt ||'');
-        const endDate = new Date(startDate.valueOf() + (attempt.wallClockDuration || 0));
+        const startDate = new Date(attempt.wallClockStartedAt || attempt.startedAt ||'');
+        const endDate = new Date(startDate.valueOf() + (attempt.wallClockDuration || attempt.duration || 0));
 
         const req: TestRunRequestBody = {
           name: test.title.join(' '),
-          start_time: attempt.wallClockStartedAt || '',
+          start_time: startDate.toISOString(),
           end_time: endDate.toISOString(),
-          duration: attempt.wallClockDuration || 0,
+          duration: attempt.wallClockDuration || attempt.duration || 0,
 
           browser: `${this.cypressDetails?.browser?.name} ${this.cypressDetails?.browser?.version}`,
           build_name: this.opts.build,

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -372,8 +372,8 @@ async function getCodeBody(specName: string, test: TestResult) {
     return [];
   }
 
-  const codeFrame = test.attempts[0].error?.codeFrame;
   const errInfo = test.attempts[0].error;
+  const codeFrame = errInfo?.codeFrame;
   if (!codeFrame || !errInfo) {
     return [];
   }


### PR DESCRIPTION
Add stricter type checking by specifying more concrete types wherever possible.
Cypress' own types are much stronger defined (by us) as well now.

Added inline docs where more clarity was needed.