### PR TITLE
fix: attach screenshots to the spec level suite

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -325,6 +325,14 @@ export default class Reporter {
         });
       }
 
+      result.screenshots?.forEach((s) => {
+        specSuite.attach({
+          name: 'screenshot',
+          path: path.basename(s.path),
+          contentType: 'image/png',
+        });
+      });
+
       // inferSuite returns the most appropriate suite for the test, while creating a new one along the way if necessary.
       // The 'title' parameter is a bit misleading, since it's an array of strings, with the last element being the actual test name.
       // All other elements are the context of the test, coming from 'describe()' and 'context()'.
@@ -367,14 +375,6 @@ export default class Reporter {
           startTime: startedAt,
           output: t.displayError || '',
           videoTimestamp,
-        });
-
-        result.screenshots?.forEach((s) => {
-          suite.attach({
-            name: 'screenshot',
-            path: path.basename(s.path),
-            contentType: 'image/png',
-          });
         });
       }
     }


### PR DESCRIPTION
Attach screenshots to the spec level suite, as we lack any more detailed information in which `describe()`, `context()` or `it()` they were created in.

This change also addresses a bug that causes screenshots to appear multiple times in the report, at least once per test case (as they were added to the suite inside the test cases loop).