### PR TITLE
fix: Remove '#' character from asset names

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -200,7 +200,7 @@ export default class Reporter {
     for (const s of screenshots) {
       assets.push({
         data: fs.createReadStream(s),
-        filename: path.basename(s),
+        filename: path.basename(s).replaceAll(/#/g, ''),
       });
     }
 


### PR DESCRIPTION
Job example: https://app.saucelabs.com/tests/a43f8c0aaf9d4487b91e316c0a1ee363