### PR TITLE
feat!: Support asset sync on Sauce VM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,10 @@ export async function afterRunTestReport(
     });
   }
 
-  return await rep.createSauceTestReport(testResults);
+  const reportJSON = await rep.createSauceTestReport(testResults);
+  const assets = rep.collectAssets(testResults, reportJSON);
+  rep.syncAssets(assets);
+  return reportJSON;
 }
 
 export default function (


### PR DESCRIPTION
# One-line summary

## Description
Cypress runner is just using `afterRunTestReport()` to generate Sauce report. The sync asset operation should be done in `afterRunTestReport()`.

Also removed the `syncAssets` in `onAfterSpec` callback as we only need this feature on Sauce VM.