### PR TITLE
 feat: add task to upload asset to Sauce for spec test job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,4 +87,4 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           DEBUG: "@saucelabs/cypress-plugin:*"
-        run: echo "this is fine" > tests/integration/test.log && npx jest
+        run: npx jest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install Dependencies
         run: npm ci
@@ -87,4 +87,4 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           DEBUG: "@saucelabs/cypress-plugin:*"
-        run: npx jest
+        run: echo "this is fine" > tests/integration/test.log && npx jest

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ This task allows you to upload assets (such as images or logs) to a specific Sau
 | ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `spec`              | `string`             | Path to the spec file being executed, typically provided by `__filename`.                                                                                                 |
 | `assets`            | `Asset` \| `Asset[]` | Can be a single `Asset` object or an array of `Asset` objects to be uploaded to Sauce Labs. Each `Asset` should contain a `filename` and either a `path` or `data`.       |
-| `assets[].filename` | `string`             | **Optional**. The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`). If not provided, the file path basename is used by default. |
 | `assets[].path`     | `string`             | **Required**. Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`).                                                                                 |
+| `assets[].filename` | `string`             | **Optional**. The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`). If not provided, the file path basename is used by default. |
 
 ### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ it("upload assets", () => {
   // Single file upload.
   cy.task("sauce:uploadAssets", {
     spec: __filename,
-    assets: { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
+    assets: { path: "pics/this-is-fine.png" },
   });
 
   // Multiple files upload.
@@ -160,7 +160,7 @@ it("upload assets", () => {
     spec: __filename,
     assets: [
       { path: "pics/this-is-fine.png" },
-      { filename: "test.log", path: "test.txt" },
+      { path: "test.txt", filename: "test.log" },
     ],
   });
 });

--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ This task allows you to upload assets (such as images or logs) to a specific Sau
 | `assets[].path`     | `string`             | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `path` or `data` must be provided.                                 |
 | `assets[].data`     | `stream`             | **Optional.** File data as a stream, used when directly providing file content. Either `path` or `data` must be provided.                                           |
 
-|-----------|--------|-------------|
-
 ### Example Usage
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ Jobs reported to Sauce Labs:
 
 This task allows you to upload assets (such as images or logs) to a specific Sauce Labs job associated with the test spec.
 
-| Parameter           | Type                 | Description                                                                                                                                                         |
-| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spec`              | `string`             | Path to the spec file being executed, typically provided by `__filename`.                                                                                           |
-| `assets`            | `Asset` \| `Asset[]` | Can be a single `Asset` object or an array of `Asset` objects to be uploaded to Sauce Labs. Each `Asset` should contain a `filename` and either a `path` or `data`. |
-| `assets[].filename` | `string`             | The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                                                                     |
-| `assets[].path`     | `string`             | Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`).                                                                                         |
+| Parameter           | Type                 | Description                                                                                                                                                               |
+| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec`              | `string`             | Path to the spec file being executed, typically provided by `__filename`.                                                                                                 |
+| `assets`            | `Asset` \| `Asset[]` | Can be a single `Asset` object or an array of `Asset` objects to be uploaded to Sauce Labs. Each `Asset` should contain a `filename` and either a `path` or `data`.       |
+| `assets[].filename` | `string`             | **Optional**. The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`). If not provided, the file path basename is used by default. |
+| `assets[].path`     | `string`             | **Required**. Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`).                                                                                 |
 
 ### Example Usage
 
@@ -159,8 +159,8 @@ it("upload assets", () => {
   cy.task("sauce:uploadAssets", {
     spec: __filename,
     assets: [
-      { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
-      { filename: "test.log", path: "test.log" },
+      { path: "pics/this-is-fine.png" },
+      { filename: "test.log", path: "test.txt" },
     ],
   });
 });

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This task allows you to upload assets (such as images or logs) to a specific Sau
 it("upload assets", () => {
   cy.task("sauce:uploadAssets", {
     spec: __filename,
-    asset: [
+    assets: [
       { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
       { filename: "test.log", data: testLogStream },
     ],

--- a/README.md
+++ b/README.md
@@ -142,9 +142,8 @@ This task allows you to upload assets (such as images or logs) to a specific Sau
 | ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `spec`              | `string`             | Path to the spec file being executed, typically provided by `__filename`.                                                                                           |
 | `assets`            | `Asset` \| `Asset[]` | Can be a single `Asset` object or an array of `Asset` objects to be uploaded to Sauce Labs. Each `Asset` should contain a `filename` and either a `path` or `data`. |
-| `assets[].filename` | `string`             | **Required.** The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                                                       |
-| `assets[].path`     | `string`             | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `path` or `data` must be provided.                                 |
-| `assets[].data`     | `stream`             | **Optional.** File data as a stream, used when directly providing file content. Either `path` or `data` must be provided.                                           |
+| `assets[].filename` | `string`             | The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                                                                     |
+| `assets[].path`     | `string`             | Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`).                                                                                         |
 
 ### Example Usage
 
@@ -161,7 +160,7 @@ it("upload assets", () => {
     spec: __filename,
     assets: [
       { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
-      { filename: "test.log", data: testLogStream },
+      { filename: "test.log", path: "test.log" },
     ],
   });
 });

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ Sauce Labs. Your Sauce Labs Username and Access Key are available from your
 Example `cypress.config.cjs`:
 
 ```javascript
-const { defineConfig } = require('cypress');
+const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      require('@saucelabs/cypress-plugin').default(on, config, {
-        region: 'us-west-1',
-        build: 'myBuild',
-        tags: ['example1'],
+      require("@saucelabs/cypress-plugin").default(on, config, {
+        region: "us-west-1",
+        build: "myBuild",
+        tags: ["example1"],
       });
       return config;
     },
@@ -51,16 +51,16 @@ module.exports = defineConfig({
 Example `cypress.config.mjs`:
 
 ```javascript
-import { defineConfig } from 'cypress';
-import reporter from '@saucelabs/cypress-plugin';
+import { defineConfig } from "cypress";
+import reporter from "@saucelabs/cypress-plugin";
 
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       reporter.default(on, config, {
-        region: 'us-west-1',
-        build: 'myBuild',
-        tags: ['example1'],
+        region: "us-west-1",
+        build: "myBuild",
+        tags: ["example1"],
       });
       return config;
     },
@@ -71,16 +71,16 @@ export default defineConfig({
 Example `cypress.config.ts`:
 
 ```typescript
-import { defineConfig } from 'cypress';
-import Reporter, { Region } from '@saucelabs/cypress-plugin';
+import { defineConfig } from "cypress";
+import Reporter, { Region } from "@saucelabs/cypress-plugin";
 
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       Reporter(on, config, {
         region: Region.USWest1, // us-west-1 is the default
-        build: 'myBuild',
-        tags: ['example1'],
+        build: "myBuild",
+        tags: ["example1"],
       });
       return config;
     },
@@ -96,10 +96,10 @@ Register the plugin in your project's `cypress/plugins/index.js`:
 module.exports = (on, config) => {
   // Other plugins you may already have.
   // ...
-  require('@saucelabs/cypress-plugin').default(on, config, {
-    region: 'us-west-1',
-    build: 'myBuild',
-    tags: ['example1'],
+  require("@saucelabs/cypress-plugin").default(on, config, {
+    region: "us-west-1",
+    build: "myBuild",
+    tags: ["example1"],
   });
   return config;
 };
@@ -132,6 +132,33 @@ Jobs reported to Sauce Labs:
   ├────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
   │  cypress/e2e/1-getting-started/todo.cy.js    https://app.saucelabs.com/tests/b30ffb871827408c81e454103b946c99  │
   └────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Upload Assets Task
+
+This task allows you to upload assets (such as images or logs) to a specific Sauce Labs job associated with the test spec.
+
+| Parameter        | Type     | Description                                                                                                                                     |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec`           | `string` | Path to the spec file being executed, typically provided by `__filename`.                                                                       |
+| `asset`          | `object` | Object containing information about the asset (file) to be uploaded to Sauce Labs.                                                              |
+| `asset.filename` | `string` | **Required.** The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                                   |
+| `asset.path`     | `string` | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `asset.path` or `asset.data` must be provided. |
+| `asset.data`     | `stream` | **Optional.** File data as a stream, used when directly providing file content. Either `asset.path` or `asset.data` must be provided.           |
+
+### Example Usage
+
+```javascript
+it("upload assets", () => {
+  cy.task("sauce:uploadAsset", {
+    spec: __filename,
+    asset: { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
+  });
+  cy.task("sauce:uploadAsset", {
+    spec: __filename,
+    asset: { filename: "test.log", path: "test.log" },
+  });
+});
 ```
 
 ## Real-life Example

--- a/README.md
+++ b/README.md
@@ -138,13 +138,15 @@ Jobs reported to Sauce Labs:
 
 This task allows you to upload assets (such as images or logs) to a specific Sauce Labs job associated with the test spec.
 
-| Parameter           | Type     | Description                                                                                                                         |
-| ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `spec`              | `string` | Path to the spec file being executed, typically provided by `__filename`.                                                           |
-| `assets`            | `array`  | Array of asset objects to be uploaded to Sauce Labs, each containing a `filename` and either `path` or `data`.                      |
-| `assets[].filename` | `string` | **Required.** The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                       |
-| `assets[].path`     | `string` | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `path` or `data` must be provided. |
-| `assets[].data`     | `stream` | **Optional.** File data as a stream, used when directly providing file content. Either `path` or `data` must be provided.           |
+| Parameter           | Type                 | Description                                                                                                                                                         |
+| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec`              | `string`             | Path to the spec file being executed, typically provided by `__filename`.                                                                                           |
+| `assets`            | `Asset` \| `Asset[]` | Can be a single `Asset` object or an array of `Asset` objects to be uploaded to Sauce Labs. Each `Asset` should contain a `filename` and either a `path` or `data`. |
+| `assets[].filename` | `string`             | **Required.** The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                                                       |
+| `assets[].path`     | `string`             | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `path` or `data` must be provided.                                 |
+| `assets[].data`     | `stream`             | **Optional.** File data as a stream, used when directly providing file content. Either `path` or `data` must be provided.                                           |
+
+|-----------|--------|-------------|
 
 ### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ This task allows you to upload assets (such as images or logs) to a specific Sau
 
 ```javascript
 it("upload assets", () => {
+  // Single file upload.
+  cy.task("sauce:uploadAssets", {
+    spec: __filename,
+    assets: { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
+  });
+
+  // Multiple files upload.
   cy.task("sauce:uploadAssets", {
     spec: __filename,
     assets: [

--- a/README.md
+++ b/README.md
@@ -138,25 +138,24 @@ Jobs reported to Sauce Labs:
 
 This task allows you to upload assets (such as images or logs) to a specific Sauce Labs job associated with the test spec.
 
-| Parameter        | Type     | Description                                                                                                                                     |
-| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `spec`           | `string` | Path to the spec file being executed, typically provided by `__filename`.                                                                       |
-| `asset`          | `object` | Object containing information about the asset (file) to be uploaded to Sauce Labs.                                                              |
-| `asset.filename` | `string` | **Required.** The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                                   |
-| `asset.path`     | `string` | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `asset.path` or `asset.data` must be provided. |
-| `asset.data`     | `stream` | **Optional.** File data as a stream, used when directly providing file content. Either `asset.path` or `asset.data` must be provided.           |
+| Parameter           | Type     | Description                                                                                                                         |
+| ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `spec`              | `string` | Path to the spec file being executed, typically provided by `__filename`.                                                           |
+| `assets`            | `array`  | Array of asset objects to be uploaded to Sauce Labs, each containing a `filename` and either `path` or `data`.                      |
+| `assets[].filename` | `string` | **Required.** The name of the file to upload, as it should appear in Sauce Labs (e.g., `"this-is-fine.png"`).                       |
+| `assets[].path`     | `string` | **Optional.** Path to the file on the local filesystem (e.g., `"pics/this-is-fine.png"`). Either `path` or `data` must be provided. |
+| `assets[].data`     | `stream` | **Optional.** File data as a stream, used when directly providing file content. Either `path` or `data` must be provided.           |
 
 ### Example Usage
 
 ```javascript
 it("upload assets", () => {
-  cy.task("sauce:uploadAsset", {
+  cy.task("sauce:uploadAssets", {
     spec: __filename,
-    asset: { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
-  });
-  cy.task("sauce:uploadAsset", {
-    spec: __filename,
-    asset: { filename: "test.log", path: "test.log" },
+    asset: [
+      { filename: "this-is-fine.png", path: "pics/this-is-fine.png" },
+      { filename: "test.log", data: testLogStream },
+    ],
   });
 });
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,6 @@ export default ts.config(
         require: true,
         process: true,
         CypressCommandLine: true,
-        Buffer: true,
       },
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,7 @@ export default ts.config(
     languageOptions: {
       globals: {
         __dirname: true,
+        __filename: true,
         console: true,
         exports: true,
         module: true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,7 @@ export default ts.config(
         require: true,
         process: true,
         CypressCommandLine: true,
+        Buffer: true,
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ const cacheAssets = ({
     if (!asset || !asset.filename) {
       throw new Error("'filename' parameter is required.");
     }
-    if (!asset.path && !asset.data) {
+    if (!asset.path) {
       throw new Error("Either 'path' or 'data' must be provided.");
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export interface Options {
 }
 
 let reporterInstance: Reporter;
-let specAssets: Map<string, Asset[]>;
+let specAssetsMap: Map<string, Asset[]>;
 const reportedSpecs: { name: string; jobURL: string }[] = [];
 
 const isAccountSet = function () {
@@ -44,7 +44,7 @@ const onAfterSpec = async function (
   }
 
   try {
-    const job = await reporterInstance.reportSpec(results, specAssets);
+    const job = await reporterInstance.reportSpec(results, specAssetsMap);
     if (!job?.id || !job?.url) {
       return;
     }
@@ -168,9 +168,9 @@ const cacheAsset = ({ spec, asset }: { spec: string; asset: Asset }): null => {
   // The spec name in the Cypress report uses the basename of the spec file.
   // To ensure matching during upload, convert it to the basename here as well.
   const specName = path.basename(spec);
-  const assets = specAssets.get(specName) || [];
+  const assets = specAssetsMap.get(specName) || [];
   assets.push(asset);
-  specAssets.set(specName, assets);
+  specAssetsMap.set(specName, assets);
 
   return null; // Cypress task requirement.
 };
@@ -181,7 +181,7 @@ export default function (
   opts?: Options,
 ) {
   reporterInstance = new Reporter(undefined, opts);
-  specAssets = new Map();
+  specAssetsMap = new Map();
 
   on("task", {
     "sauce:uploadAsset": cacheAsset,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,10 @@ export interface Options {
 }
 
 let reporterInstance: Reporter;
-let specAssetsMap: Map<string, Asset[]>;
 const reportedSpecs: { name: string; jobURL: string }[] = [];
+
+// Maps spec names to their associated assets, cached for later upload.
+let specAssetsMap: Map<string, Asset[]>;
 
 const isAccountSet = function () {
   return process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ let reporterInstance: Reporter;
 const reportedSpecs: { name: string; jobURL: string }[] = [];
 
 // Maps spec names to their associated assets, cached for later upload.
-let specAssetsMap: Map<string, Asset[]>;
+let specToAssets: Map<string, Asset[]>;
 
 const isAccountSet = function () {
   return process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY;
@@ -46,7 +46,7 @@ const onAfterSpec = async function (
   }
 
   try {
-    const job = await reporterInstance.reportSpec(results, specAssetsMap);
+    const job = await reporterInstance.reportSpec(results, specToAssets);
     if (!job?.id || !job?.url) {
       return;
     }
@@ -180,9 +180,9 @@ const cacheAssets = ({
   // The spec name in the Cypress report uses the basename of the spec file.
   // To ensure matching during upload, convert it to the basename here as well.
   const specName = path.basename(spec);
-  const currAssets = specAssetsMap.get(specName) || [];
+  const currAssets = specToAssets.get(specName) || [];
   currAssets.push(...assetsArray);
-  specAssetsMap.set(specName, currAssets);
+  specToAssets.set(specName, currAssets);
 
   return null; // Cypress task requirement.
 };
@@ -193,7 +193,7 @@ export default function (
   opts?: Options,
 ) {
   reporterInstance = new Reporter(undefined, opts);
-  specAssetsMap = new Map();
+  specToAssets = new Map();
 
   on("task", {
     "sauce:uploadAssets": cacheAssets,

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,11 +147,21 @@ const collectAsset = ({
   spec: string;
   asset: Asset;
 }): null => {
+  if (!spec) {
+    throw new Error("'spec' parameter is required.");
+  }
+  if (!asset || !asset.filename) {
+    throw new Error("'asset.filename' parameter is required.");
+  }
+  if (!asset.path && !asset.data) {
+    throw new Error("Either 'asset.path' or 'asset.data' must be provided.");
+  }
+
   if (asset.path) {
     const resolvedPath = path.resolve(asset.path);
 
     if (!fs.existsSync(resolvedPath)) {
-      throw new Error(`Attachment failed: File not found at (${resolvedPath})`);
+      throw new Error(`File not found at path '${resolvedPath}'.`);
     }
 
     asset.data = fs.createReadStream(resolvedPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,19 +161,16 @@ const cacheAssets = ({
     throw new Error("'assets' is required.");
   }
   assetsArray.forEach((asset: Asset) => {
-    if (!asset || !asset.filename) {
-      throw new Error("'filename' parameter is required.");
-    }
     if (!asset.path) {
-      throw new Error("Either 'path' or 'data' must be provided.");
+      throw new Error("'path' is required.");
     }
-
-    if (asset.path) {
-      const resolvedPath = path.resolve(asset.path);
-      if (!fs.existsSync(resolvedPath)) {
-        throw new Error(`File not found at path '${resolvedPath}'.`);
-      }
-      asset.data = fs.createReadStream(resolvedPath);
+    const resolvedPath = path.resolve(asset.path);
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`File not found at path '${resolvedPath}'.`);
+    }
+    asset.data = fs.createReadStream(resolvedPath);
+    if (!asset.filename) {
+      asset.filename = path.basename(asset.path);
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,13 +140,11 @@ export async function afterRunTestReport(
   return reportJSON;
 }
 
-const collectAsset = ({
-  spec,
-  asset,
-}: {
-  spec: string;
-  asset: Asset;
-}): null => {
+/**
+ * Temporarily caches an asset for the current spec test job.
+ * Assets collected by this function are stored and later uploaded in `onAfterSpec`.
+ **/
+const cacheAsset = ({ spec, asset }: { spec: string; asset: Asset }): null => {
   if (!spec) {
     throw new Error("'spec' parameter is required.");
   }
@@ -184,7 +182,7 @@ export default function (
   specAssets = new Map();
 
   on("task", {
-    "sauce:uploadAsset": collectAsset,
+    "sauce:uploadAsset": cacheAsset,
   });
   on("before:run", onBeforeRun);
   on("after:run", onAfterRun);

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,8 @@ const cacheAsset = ({ spec, asset }: { spec: string; asset: Asset }): null => {
     asset.data = fs.createReadStream(resolvedPath);
   }
 
+  // The spec name in the Cypress report uses the basename of the spec file.
+  // To ensure matching during upload, convert it to the basename here as well.
   const specName = path.basename(spec);
   const assets = specAssets.get(specName) || [];
   assets.push(asset);

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export async function afterRunTestReport(
  **/
 const cacheAssets = ({
   spec,
-  assets,
+  ...assets
 }: {
   spec: string;
   assets: Asset[];
@@ -156,10 +156,11 @@ const cacheAssets = ({
   if (!spec) {
     throw new Error("'spec' is required.");
   }
-  if (!assets) {
+  const assetsArray = Object.values(assets).flat();
+  if (assetsArray.length === 0) {
     throw new Error("'assets' is required.");
   }
-  assets.forEach((asset: Asset) => {
+  assetsArray.forEach((asset: Asset) => {
     if (!asset || !asset.filename) {
       throw new Error("'filename' parameter is required.");
     }
@@ -180,7 +181,7 @@ const cacheAssets = ({
   // To ensure matching during upload, convert it to the basename here as well.
   const specName = path.basename(spec);
   const currAssets = specAssetsMap.get(specName) || [];
-  currAssets.push(...assets);
+  currAssets.push(...assetsArray);
   specAssetsMap.set(specName, currAssets);
 
   return null; // Cypress task requirement.

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -120,7 +120,7 @@ export default class Reporter {
   }
 
   // Reports a spec as a Job on Sauce.
-  async reportSpec(result: RunResult, specAssets: Map<string, Asset[]>) {
+  async reportSpec(result: RunResult, specAssetsMap: Map<string, Asset[]>) {
     if (!this.testComposer) {
       return;
     }
@@ -147,7 +147,7 @@ export default class Reporter {
 
     const report = await this.createSauceTestReport([result]);
     const assets = await this.collectAssets([result], report);
-    assets.push(...(specAssets.get(result.spec.name) || []));
+    assets.push(...(specAssetsMap.get(result.spec.name) || []));
     await this.uploadAssets(job.id, assets);
 
     return job;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -120,7 +120,7 @@ export default class Reporter {
   }
 
   // Reports a spec as a Job on Sauce.
-  async reportSpec(result: RunResult) {
+  async reportSpec(result: RunResult, specAssets: Map<string, Asset[]>) {
     if (!this.testComposer) {
       return;
     }
@@ -147,6 +147,7 @@ export default class Reporter {
 
     const report = await this.createSauceTestReport([result]);
     const assets = await this.collectAssets([result], report);
+    assets.push(...(specAssets.get(result.spec.name) || []));
     await this.uploadAssets(job.id, assets);
 
     return job;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -120,7 +120,7 @@ export default class Reporter {
   }
 
   // Reports a spec as a Job on Sauce.
-  async reportSpec(result: RunResult, specAssetsMap: Map<string, Asset[]>) {
+  async reportSpec(result: RunResult, specToAssets: Map<string, Asset[]>) {
     if (!this.testComposer) {
       return;
     }
@@ -147,7 +147,7 @@ export default class Reporter {
 
     const report = await this.createSauceTestReport([result]);
     const assets = await this.collectAssets([result], report);
-    assets.push(...(specAssetsMap.get(result.spec.name) || []));
+    assets.push(...(specToAssets.get(result.spec.name) || []));
     await this.uploadAssets(job.id, assets);
 
     return job;

--- a/tests/integration/cypress.config.js
+++ b/tests/integration/cypress.config.js
@@ -1,4 +1,6 @@
 const { defineConfig } = require("cypress");
+const fs = require("fs");
+const path = require("path");
 
 module.exports = defineConfig({
   e2e: {
@@ -8,6 +10,26 @@ module.exports = defineConfig({
         build: "Cypress Kitchensink Example",
         tags: ["plugin", "kitchensink", "cypress"],
         region: "us-west-1",
+      });
+
+      on("task", {
+        readFileAsStream({ filePath }) {
+          return new Promise((resolve, reject) => {
+            const resolvedPath = path.resolve(filePath);
+            if (!fs.existsSync(resolvedPath)) {
+              return reject(
+                new Error(`File not found at path: ${resolvedPath}`),
+              );
+            }
+
+            const stream = fs.createReadStream(resolvedPath);
+            const chunks = [];
+
+            stream.on("data", (chunk) => chunks.push(chunk));
+            stream.on("end", () => resolve(Buffer.concat(chunks).toString()));
+            stream.on("error", reject);
+          });
+        },
       });
 
       return config;

--- a/tests/integration/cypress.config.js
+++ b/tests/integration/cypress.config.js
@@ -1,6 +1,4 @@
 const { defineConfig } = require("cypress");
-const fs = require("fs");
-const path = require("path");
 
 module.exports = defineConfig({
   e2e: {
@@ -10,26 +8,6 @@ module.exports = defineConfig({
         build: "Cypress Kitchensink Example",
         tags: ["plugin", "kitchensink", "cypress"],
         region: "us-west-1",
-      });
-
-      on("task", {
-        readFileAsStream({ filePath }) {
-          return new Promise((resolve, reject) => {
-            const resolvedPath = path.resolve(filePath);
-            if (!fs.existsSync(resolvedPath)) {
-              return reject(
-                new Error(`File not found at path: ${resolvedPath}`),
-              );
-            }
-
-            const stream = fs.createReadStream(resolvedPath);
-            const chunks = [];
-
-            stream.on("data", (chunk) => chunks.push(chunk));
-            stream.on("end", () => resolve(Buffer.concat(chunks).toString()));
-            stream.on("error", reject);
-          });
-        },
       });
 
       return config;

--- a/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
+++ b/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
@@ -42,19 +42,13 @@ describe("example to-do app", () => {
       assets: { filename: "test1.log", path: "test.txt" },
     });
 
-    // In Cypress test, we can't use fs.createReadStream() directly due to its browser-like env.
-    // Creating a file stream requires handling it through a Cypress task.
-    cy.task("readFileAsStream", { filePath: "test.txt" }).then(
-      (testLogStream) => {
-        // Multiple files upload.
-        cy.task("sauce:uploadAssets", {
-          spec: __filename,
-          assets: [
-            { filename: "test2.log", path: "test.txt" },
-            { filename: "test3.log", data: testLogStream },
-          ],
-        });
-      },
-    );
+    // Multiple files upload.
+    cy.task("sauce:uploadAssets", {
+      spec: __filename,
+      assets: [
+        { filename: "test2.log", path: "test.txt" },
+        { filename: "test3.log", path: "test.txt" },
+      ],
+    });
   });
 });

--- a/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
+++ b/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
@@ -39,18 +39,18 @@ describe("example to-do app", () => {
     // Single file upload.
     cy.task("sauce:uploadAssets", {
       spec: __filename,
-      assets: { filename: "test1.log", path: "test.log" },
+      assets: { filename: "test1.log", path: "test.txt" },
     });
 
     // Cypress can't use fs.createReadStream() directly due to its browser-like env.
     // Creating a file stream requires handling it through a Cypress task.
-    cy.task("readFileAsStream", { filePath: "test.log" }).then(
+    cy.task("readFileAsStream", { filePath: "test.txt" }).then(
       (testLogStream) => {
         // Multiple files upload.
         cy.task("sauce:uploadAssets", {
           spec: __filename,
           assets: [
-            { filename: "test2.log", path: "test.log" },
+            { filename: "test2.log", path: "test.txt" },
             { filename: "test3.log", data: testLogStream },
           ],
         });

--- a/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
+++ b/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
@@ -42,7 +42,7 @@ describe("example to-do app", () => {
       assets: { filename: "test1.log", path: "test.txt" },
     });
 
-    // Cypress can't use fs.createReadStream() directly due to its browser-like env.
+    // In Cypress test, we can't use fs.createReadStream() directly due to its browser-like env.
     // Creating a file stream requires handling it through a Cypress task.
     cy.task("readFileAsStream", { filePath: "test.txt" }).then(
       (testLogStream) => {

--- a/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
+++ b/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
@@ -47,7 +47,7 @@ describe("example to-do app", () => {
       spec: __filename,
       assets: [
         { filename: "test2.log", path: "test.txt" },
-        { filename: "test3.log", path: "test.txt" },
+        { path: "test.txt" },
       ],
     });
   });

--- a/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
+++ b/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
@@ -10,6 +10,7 @@
 // what makes it such an awesome testing tool,
 // please read our getting started guide:
 // https://on.cypress.io/introduction-to-cypress
+import * as fs from "fs";
 
 describe("example to-do app", () => {
   beforeEach(() => {
@@ -33,5 +34,24 @@ describe("example to-do app", () => {
     // and then perform an assertion with `should`.
     cy.get(".todo-list li").first().should("have.text", "Pay electric bill");
     cy.get(".todo-list li").last().should("have.text", "Walk the dog");
+  });
+
+  it("upload assets", () => {
+    // Single file upload.
+    cy.task("sauce:uploadAssets", {
+      spec: __filename,
+      assets: { filename: "test1.log", path: "test.log" },
+    });
+
+    const testLogStream = fs.createReadStream("test.log");
+
+    // Multiple files upload.
+    cy.task("sauce:uploadAssets", {
+      spec: __filename,
+      assets: [
+        { filename: "test2.log", path: "test.log" },
+        { filename: "test3.log", data: testLogStream },
+      ],
+    });
   });
 });

--- a/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
+++ b/tests/integration/cypress/e2e/1-getting-started/todo.cy.js
@@ -10,7 +10,6 @@
 // what makes it such an awesome testing tool,
 // please read our getting started guide:
 // https://on.cypress.io/introduction-to-cypress
-import * as fs from "fs";
 
 describe("example to-do app", () => {
   beforeEach(() => {
@@ -36,22 +35,26 @@ describe("example to-do app", () => {
     cy.get(".todo-list li").last().should("have.text", "Walk the dog");
   });
 
-  it("upload assets", () => {
+  it("uploads assets", () => {
     // Single file upload.
     cy.task("sauce:uploadAssets", {
       spec: __filename,
       assets: { filename: "test1.log", path: "test.log" },
     });
 
-    const testLogStream = fs.createReadStream("test.log");
-
-    // Multiple files upload.
-    cy.task("sauce:uploadAssets", {
-      spec: __filename,
-      assets: [
-        { filename: "test2.log", path: "test.log" },
-        { filename: "test3.log", data: testLogStream },
-      ],
-    });
+    // Cypress can't use fs.createReadStream() directly due to its browser-like env.
+    // Creating a file stream requires handling it through a Cypress task.
+    cy.task("readFileAsStream", { filePath: "test.log" }).then(
+      (testLogStream) => {
+        // Multiple files upload.
+        cy.task("sauce:uploadAssets", {
+          spec: __filename,
+          assets: [
+            { filename: "test2.log", path: "test.log" },
+            { filename: "test3.log", data: testLogStream },
+          ],
+        });
+      },
+    );
   });
 });

--- a/tests/integration/test.txt
+++ b/tests/integration/test.txt
@@ -1,1 +1,1 @@
-This is the log file and will be uploaded in Cypress task test.
+This is the log file, which will be uploaded during the Cypress task test.

--- a/tests/integration/test.txt
+++ b/tests/integration/test.txt
@@ -1,0 +1,1 @@
+This is the log file and will be uploaded in Cypress task test.


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

Add a Cypress task `sauce:uploadAsset` (or a different name if preferred) to upload an asset to the spec test job.

Job example, I attached two pictures and a `test.log`: https://app.saucelabs.com/tests/b1ac7308d816424f91f3e973496ec0bc