### PR TITLE
refactor: improve asset collections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export async function afterRunTestReport(
   }
 
   const reportJSON = await rep.createSauceTestReport(testResults);
-  const assets = await rep.collectAssets(testResults, reportJSON);
+  const assets = await rep.collectAssets(testResults);
   rep.syncAssets(assets);
   return reportJSON;
 }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -473,11 +473,10 @@ export default class Reporter {
   }
 
   /**
-   * Collects assets for the console log and sauce-test-report.json.
+   * Collects assets for the sauce-test-report.json.
    *
-   * @param result - The result of the test run to generate the console log.
    * @param report - The sauce test report to be attached as an asset.
-   * @returns An array of assets containing the console log and sauce test report.
+   * @returns Sauce test report asset.
    */
   getSauceTestReport(report: TestRun): Asset {
     return {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -148,7 +148,8 @@ export default class Reporter {
     const report = await this.createSauceTestReport([result]);
     const assets = await this.collectAssets([result]);
     assets.push(
-      ...this.collectLogsAndReport(result, report),
+      this.getConsoleLog(result),
+      this.getSauceTestReport(report),
       ...(specToAssets.get(result.spec.name) || []),
     );
     await this.uploadAssets(job.id, assets);
@@ -241,7 +242,7 @@ export default class Reporter {
     );
   }
 
-  getConsoleLog(result: RunResult) {
+  genConsoleLog(result: RunResult) {
     let consoleLog = `Running: ${result.spec.name}\n\n`;
 
     const tree = this.orderContexts(result.tests);
@@ -459,23 +460,30 @@ export default class Reporter {
   }
 
   /**
+   * Collects console log.
+   *
+   * @param result - The result of the test run to generate the console log.
+   * @returns Console log asset.
+   */
+  getConsoleLog(result: RunResult): Asset {
+    return {
+      data: this.ReadableStream(this.genConsoleLog(result)),
+      filename: "console.log",
+    };
+  }
+
+  /**
    * Collects assets for the console log and sauce-test-report.json.
    *
    * @param result - The result of the test run to generate the console log.
    * @param report - The sauce test report to be attached as an asset.
    * @returns An array of assets containing the console log and sauce test report.
    */
-  collectLogsAndReport(result: RunResult, report: TestRun): Asset[] {
-    return [
-      {
-        data: this.ReadableStream(this.getConsoleLog(result)),
-        filename: "console.log",
-      },
-      {
-        data: this.ReadableStream(report.stringify()),
-        filename: "sauce-test-report.json",
-      },
-    ];
+  getSauceTestReport(report: TestRun): Asset {
+    return {
+      data: this.ReadableStream(report.stringify()),
+      filename: "sauce-test-report.json",
+    };
   }
 
   /**

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -459,12 +459,6 @@ export default class Reporter {
     return assets;
   }
 
-  /**
-   * Collects console log.
-   *
-   * @param result - The result of the test run to generate the console log.
-   * @returns Console log asset.
-   */
   getConsoleLog(result: RunResult): Asset {
     return {
       data: this.ReadableStream(this.genConsoleLog(result)),
@@ -472,12 +466,6 @@ export default class Reporter {
     };
   }
 
-  /**
-   * Collects assets for the sauce-test-report.json.
-   *
-   * @param report - The sauce test report to be attached as an asset.
-   * @returns Sauce test report asset.
-   */
   getSauceTestReport(report: TestRun): Asset {
     return {
       data: this.ReadableStream(report.stringify()),

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -146,8 +146,11 @@ export default class Reporter {
     });
 
     const report = await this.createSauceTestReport([result]);
-    const assets = await this.collectAssets([result], report);
-    assets.push(...(specToAssets.get(result.spec.name) || []));
+    const assets = await this.collectAssets([result]);
+    assets.push(
+      ...this.collectLogsAndReport(result, report),
+      ...(specToAssets.get(result.spec.name) || []),
+    );
     await this.uploadAssets(job.id, assets);
 
     return job;
@@ -424,13 +427,12 @@ export default class Reporter {
 
   /**
    * Gathers test assets for upload to Sauce through the TestComposer API.
-   * Assets include videos, screenshots, console logs, and the Sauce JSON report.
+   * Assets include videos, screenshots and additional artifacts from a specified directory.
    *
    * @param {RunResult[]} results - Contains video and screenshot paths from a Cypress test run.
-   * @param {TestRun} report - The Sauce JSON report object.
-   * @returns {Asset[]} Array of assets, each with a filename and data stream, ready for upload.
+   * @returns {Asset[]} An array of assets, each with a filename and data stream, ready for upload.
    */
-  async collectAssets(results: RunResult[], report: TestRun): Promise<Asset[]> {
+  async collectAssets(results: RunResult[]): Promise<Asset[]> {
     const assets: Asset[] = [];
     for (const result of results) {
       const specName = result.spec.name;
@@ -449,38 +451,66 @@ export default class Reporter {
         });
       });
 
-      if (this.opts.artifactUploadDir) {
-        const artifactPath = path.join(this.opts.artifactUploadDir, specName);
-        if (fs.existsSync(artifactPath)) {
-          const entries = await readdir(path.resolve(artifactPath), {
-            withFileTypes: true,
-          });
+      const artifacts = await this.collectArtifacts(specName);
+      assets.push(...artifacts);
+    }
 
-          for (const entry of entries) {
-            if (!entry.isFile()) {
-              continue;
-            }
+    return assets;
+  }
 
-            const entryPath = path.join(artifactPath, entry.name);
-            assets.push({
-              filename: entry.name,
-              path: entryPath,
-              data: fs.createReadStream(path.resolve(entryPath)),
-            });
-          }
-        }
+  /**
+   * Collects assets for the console log and sauce-test-report.json.
+   *
+   * @param result - The result of the test run to generate the console log.
+   * @param report - The sauce test report to be attached as an asset.
+   * @returns An array of assets containing the console log and sauce test report.
+   */
+  collectLogsAndReport(result: RunResult, report: TestRun): Asset[] {
+    return [
+      {
+        data: this.ReadableStream(this.getConsoleLog(result)),
+        filename: "console.log",
+      },
+      {
+        data: this.ReadableStream(report.stringify()),
+        filename: "sauce-test-report.json",
+      },
+    ];
+  }
+
+  /**
+   * Collects additional artifacts from a specified directory.
+   *
+   * @param specName - The name of the spec for which artifacts are being collected.
+   * @returns - An array of assets representing the artifacts.
+   */
+  async collectArtifacts(specName: string): Promise<Asset[]> {
+    const assets: Asset[] = [];
+    if (!this.opts.artifactUploadDir) {
+      return assets;
+    }
+
+    const artifactPath = path.join(this.opts.artifactUploadDir, specName);
+
+    if (!fs.existsSync(artifactPath)) {
+      return assets;
+    }
+
+    const entries = await readdir(path.resolve(artifactPath), {
+      withFileTypes: true,
+    });
+
+    for (const entry of entries) {
+      if (!entry.isFile()) {
+        continue;
       }
 
-      assets.push(
-        {
-          data: this.ReadableStream(this.getConsoleLog(result)),
-          filename: "console.log",
-        },
-        {
-          data: this.ReadableStream(report.stringify()),
-          filename: "sauce-test-report.json",
-        },
-      );
+      const entryPath = path.join(artifactPath, entry.name);
+      assets.push({
+        filename: entry.name,
+        path: entryPath,
+        data: fs.createReadStream(path.resolve(entryPath)),
+      });
     }
 
     return assets;


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->

When acting as a Cypress plugin, it collects console.log and sauce-test-report.json for upload.
When invoked by the Cypress runner, it should skip collecting the console log and test report files.

Functions were split for clarity and separation of responsibilities.